### PR TITLE
Accept --path on download credentials

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,16 +24,16 @@ func writeCluster(w *tabwriter.Writer, cluster *libcarina.Cluster) {
 }
 
 func writeCredentials(w *tabwriter.Writer, creds *libcarina.Credentials, pth string) (err error) {
-	statusFormat := "%s\t%s\n"
+	// TODO: Prompt when file already exists?
 	for fname, b := range creds.Files {
 		p := path.Join(pth, fname)
 		err = ioutil.WriteFile(p, b, 0600)
 		if err != nil {
-			fmt.Fprintf(w, statusFormat, fname, "🚫")
 			return err
 		}
-		fmt.Fprintf(w, statusFormat, fname, "✅")
 	}
+	// TODO: Handle Windows separately
+	fmt.Printf("source %v\n", path.Join(pth, "docker.env"))
 	return nil
 }
 
@@ -57,6 +57,12 @@ type CarinaCommand struct {
 type CarinaClusterCommand struct {
 	*CarinaCommand
 	ClusterName string
+}
+
+// CarinaDownloadCommand keeps context about the download command
+type CarinaDownloadCommand struct {
+	*CarinaClusterCommand
+	Path string
 }
 
 // NewCarina creates a new CarinaApplication
@@ -85,7 +91,9 @@ func NewCarina() *CarinaApplication {
 	createCommand := cap.NewCarinaClusterCommand(writer, "create", "create a swarm cluster")
 	createCommand.Action(createCommand.Create)
 
-	downloadCommand := cap.NewCarinaClusterCommand(writer, "download", "download credentials")
+	downloadCommand := new(CarinaDownloadCommand)
+	downloadCommand.CarinaClusterCommand = cap.NewCarinaClusterCommand(writer, "download", "download credentials")
+	downloadCommand.Flag("path", "path to write credentials out to").StringVar(&downloadCommand.Path)
 	downloadCommand.Action(downloadCommand.Download)
 
 	return cap
@@ -183,10 +191,17 @@ func (carina *CarinaClusterCommand) Create(pc *kingpin.ParseContext) (err error)
 }
 
 // Download credentials for a cluster
-func (carina *CarinaClusterCommand) Download(pc *kingpin.ParseContext) (err error) {
+func (carina *CarinaDownloadCommand) Download(pc *kingpin.ParseContext) (err error) {
 	credentials, err := carina.ClusterClient.GetCredentials(carina.ClusterName)
+
+	p := path.Clean(carina.Path)
+
+	if p != "." {
+		os.MkdirAll(p, 0777)
+	}
+
 	if err == nil {
-		writeCredentials(carina.TabWriter, credentials, ".")
+		writeCredentials(carina.TabWriter, credentials, p)
 	}
 	carina.TabWriter.Flush()
 	return err

--- a/main.go
+++ b/main.go
@@ -32,8 +32,11 @@ func writeCredentials(w *tabwriter.Writer, creds *libcarina.Credentials, pth str
 			return err
 		}
 	}
-	// TODO: Handle Windows separately
-	fmt.Printf("source %v\n", path.Join(pth, "docker.env"))
+
+	// TODO: Handle Windows conditionally
+	fmt.Printf("source \"%v\"\n", path.Join(pth, "docker.env"))
+	fmt.Printf("# Run the above or use a subshell with your arguments to %v\n", os.Args[0])
+	fmt.Printf("# $( %v command... ) \n", os.Args[0])
 	return nil
 }
 


### PR DESCRIPTION
This lets you specify the path to download credentials to and spits out a `source <path-to-docker.env>` line:

``` bash
$ carina download nature --path ~/nature
source /Users/rgbkrk/nature/docker.env
```

Which you can also just use with standard backticks/subshells:

``` bash
$ $(carina download nature --path ~/nature)
$ docker ps
CONTAINER ID        IMAGE                                    COMMAND                  CREATED             STATUS              PORTS                       NAMES
7d996db50224        jupyter/nature-demo:latest               "/bin/sh -c 'ipython3"   2 days ago          Up 2 days           127.0.0.1:32774->8888/tcp   8d21b232-9927-4315-b3e6-ba7a102ecfc8-n1/tmp.jupyternature-demo.1kuCENazZcwL
978eaf16519c        jupyter/nature-demo:latest               "/bin/sh -c 'ipython3"   2 days ago          Up 2 days           127.0.0.1:32773->8888/tcp   8d21b232-9927-4315-b3e6-ba7a102ecfc8-n1/tmp.jupyternature-demo.z1zpq8dIiQA8
bd2bdba9cdb9        jupyter/nature-demo:latest               "/bin/sh -c 'ipython3"   2 days ago          Up 2 days           127.0.0.1:32772->8888/tcp   8d21b232-9927-4315-b3e6-ba7a102ecfc8-n1/tmp.jupyternature-demo.o98ZcQ0BzICT
51908104c9fd        jupyter/nature-demo:latest               "/bin/sh -c 'ipython3"   2 days ago          Up 2 days           127.0.0.1:32770->8888/tcp   8d21b232-9927-4315-b3e6-ba7a102ecfc8-n1/tmp.jupyternature-demo.ighqY9L7gKFp
a1a43c1e51ed        jupyter/nature-demo:latest               "/bin/sh -c 'ipython3"   2 days ago          Up 2 days           127.0.0.1:32771->8888/tcp   8d21b232-9927-4315-b3e6-ba7a102ecfc8-n1/tmp.jupyternature-demo.36CrmkknR3Ae
9f9ce70a324f        jupyter/nature-demo:latest               "/bin/sh -c 'ipython3"   2 days ago          Up 2 days           127.0.0.1:32768->8888/tcp   8d21b232-9927-4315-b3e6-ba7a102ecfc8-n1/tmp.jupyternature-demo.juQnPCqZ9AGj
cb3415d35b1b        jupyter/nature-demo:latest               "/bin/sh -c 'ipython3"   2 days ago          Up 2 days           127.0.0.1:32769->8888/tcp   8d21b232-9927-4315-b3e6-ba7a102ecfc8-n1/tmp.jupyternature-demo.xtHTOFs01rBM
7fccd8130508        jupyter/tmpnb:latest                     "python orchestrate.p"   3 weeks ago         Up 2 days                                       8d21b232-9927-4315-b3e6-ba7a102ecfc8-n1/tmpnb
a428b87b4c55        jupyter/configurable-http-proxy:latest   "configurable-http-pr"   3 weeks ago         Up 5 hours                                      8d21b232-9927-4315-b3e6-ba7a102ecfc8-n1/proxy
```

As requested by @adrianotto.
