### PR TITLE
No leaky key

### DIFF
--- a/main.go
+++ b/main.go
@@ -135,8 +135,8 @@ func (app *CarinaApplication) NewCarinaCommand(writer *tabwriter.Writer, name, h
 	carina := new(CarinaCommand)
 
 	carina.CmdClause = app.Command(name, help)
-	carina.Flag("username", "Rackspace username").Default("").OverrideDefaultFromEnvar("RACKSPACE_USERNAME").StringVar(&carina.Username)
-	carina.Flag("api-key", "Rackspace API Key").Default("").OverrideDefaultFromEnvar("RACKSPACE_APIKEY").StringVar(&carina.APIKey)
+	carina.Flag("username", "Rackspace username").StringVar(&carina.Username)
+	carina.Flag("api-key", "Rackspace API Key").StringVar(&carina.APIKey)
 	carina.Flag("endpoint", "Carina API endpoint").Default(libcarina.BetaEndpoint).StringVar(&carina.Endpoint)
 
 	carina.PreAction(carina.Auth)
@@ -157,6 +157,16 @@ func (app *CarinaApplication) NewCarinaClusterCommand(writer *tabwriter.Writer, 
 
 // Auth does the authentication
 func (carina *CarinaCommand) Auth(pc *kingpin.ParseContext) (err error) {
+	userEnv := os.Getenv("RACKSPACE_USERNAME")
+	if userEnv != "" {
+		carina.Username = userEnv
+	}
+
+	apiKeyEnv := os.Getenv("RACKSPACE_PASSWORD")
+	if apiKeyEnv != "" {
+		carina.APIKey = apiKeyEnv
+	}
+
 	carina.ClusterClient, err = libcarina.NewClusterClient(carina.Endpoint, carina.Username, carina.APIKey)
 	return err
 }

--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ func New() *Application {
 	cap.Application = app
 
 	ctx := new(Context)
+	cap.Context = ctx
 
 	cap.Flag("username", "Rackspace username").StringVar(&ctx.Username)
 	cap.Flag("api-key", "Rackspace API Key").StringVar(&ctx.APIKey)
@@ -167,7 +168,7 @@ func (app *Application) Auth(pc *kingpin.ParseContext) (err error) {
 		carina.Username = userEnv
 	}
 
-	apiKeyEnv := os.Getenv("RACKSPACE_PASSWORD")
+	apiKeyEnv := os.Getenv("RACKSPACE_APIKEY")
 	if apiKeyEnv != "" {
 		carina.APIKey = apiKeyEnv
 	}

--- a/main.go
+++ b/main.go
@@ -40,8 +40,8 @@ func writeCredentials(w *tabwriter.Writer, creds *libcarina.Credentials, pth str
 
 // Application is, our, well, application
 type Application struct {
+	*Context
 	*kingpin.Application
-	Context *Context
 }
 
 // Command is a command needing a ClusterClient
@@ -98,10 +98,9 @@ func New() *Application {
 	app := kingpin.New("carina", "command line interface to work with Docker Swarm clusters")
 
 	cap := new(Application)
+	ctx := new(Context)
 
 	cap.Application = app
-
-	ctx := new(Context)
 	cap.Context = ctx
 
 	cap.PreAction(cap.Auth)

--- a/main.go
+++ b/main.go
@@ -105,8 +105,8 @@ func New() *Application {
 
 	cap.PreAction(cap.Auth)
 
-	cap.Flag("username", "Rackspace username - can also set env var RACKSPACE_USERNAME").StringVar(&ctx.Username)
-	cap.Flag("api-key", "Rackspace API Key - can also set env var RACKSPACE_APIKEY").StringVar(&ctx.APIKey)
+	cap.Flag("username", "Rackspace username - can also set env var RACKSPACE_USERNAME").OverrideDefaultFromEnvar("RACKSPACE_USERNAME").StringVar(&ctx.Username)
+	cap.Flag("api-key", "Rackspace API Key - can also set env var RACKSPACE_APIKEY").OverrideDefaultFromEnvar("RACKSPACE_APIKEY").PlaceHolder("RACKSPACE_APIKEY").StringVar(&ctx.APIKey)
 	cap.Flag("endpoint", "Carina API endpoint").Default(libcarina.BetaEndpoint).StringVar(&ctx.Endpoint)
 
 	writer := new(tabwriter.Writer)
@@ -162,17 +162,6 @@ func (app *Application) NewClusterCommand(ctx *Context, name, help string) *Clus
 // Auth does the authentication
 func (app *Application) Auth(pc *kingpin.ParseContext) (err error) {
 	carina := app.Context
-
-	userEnv := os.Getenv("RACKSPACE_USERNAME")
-	if userEnv != "" {
-		carina.Username = userEnv
-	}
-
-	apiKeyEnv := os.Getenv("RACKSPACE_APIKEY")
-	if apiKeyEnv != "" {
-		carina.APIKey = apiKeyEnv
-	}
-
 	carina.ClusterClient, err = libcarina.NewClusterClient(carina.Endpoint, carina.Username, carina.APIKey)
 	return err
 }

--- a/main.go
+++ b/main.go
@@ -38,15 +38,20 @@ func writeCredentials(w *tabwriter.Writer, creds *libcarina.Credentials, pth str
 	return nil
 }
 
-// CarinaApplication is, our, well, application
-type CarinaApplication struct {
+// Application is, our, well, application
+type Application struct {
 	*kingpin.Application
-	TabWriter *tabwriter.Writer
+	Context *Context
 }
 
-// CarinaCommand is a command is a command needing a ClusterClient
-type CarinaCommand struct {
+// Command is a command needing a ClusterClient
+type Command struct {
 	*kingpin.CmdClause
+	Context *Context
+}
+
+// Context context for the  App
+type Context struct {
 	ClusterClient *libcarina.ClusterClient
 	TabWriter     *tabwriter.Writer
 	Username      string
@@ -54,25 +59,25 @@ type CarinaCommand struct {
 	Endpoint      string
 }
 
-// CarinaClusterCommand is a CarinaCommand with a ClusterName set
-type CarinaClusterCommand struct {
-	*CarinaCommand
+// ClusterCommand is a Command with a ClusterName set
+type ClusterCommand struct {
+	*Command
 	ClusterName string
 }
 
-// CarinaCredentialsCommand keeps context about the download command
-type CarinaCredentialsCommand struct {
-	*CarinaClusterCommand
+// CredentialsCommand keeps context about the download command
+type CredentialsCommand struct {
+	*ClusterCommand
 	Path string
 }
 
-// CarinaCreateCommand keeps context about the create command
-type CarinaCreateCommand struct {
-	*CarinaClusterCommand
+// CreateCommand keeps context about the create command
+type CreateCommand struct {
+	*ClusterCommand
 
 	Wait bool
 
-	// Options passed along to Carina itself
+	// Options passed along to Carina's API
 	Nodes     int
 	AutoScale bool
 
@@ -83,80 +88,80 @@ type CarinaCreateCommand struct {
 
 // GrowCommand keeps context about the number of nodes to scale by
 type GrowCommand struct {
-	*CarinaClusterCommand
+	*ClusterCommand
 	Nodes int
 }
 
-// NewCarina creates a new CarinaApplication
-func NewCarina() *CarinaApplication {
+// New creates a new Application
+func New() *Application {
 
 	app := kingpin.New("carina", "command line interface to work with Docker Swarm clusters")
 
-	cap := new(CarinaApplication)
+	cap := new(Application)
 
 	cap.Application = app
+
+	ctx := new(Context)
+
+	cap.Flag("username", "Rackspace username").StringVar(&ctx.Username)
+	cap.Flag("api-key", "Rackspace API Key").StringVar(&ctx.APIKey)
+	cap.Flag("endpoint", "Carina API endpoint").Default(libcarina.BetaEndpoint).StringVar(&ctx.Endpoint)
 
 	writer := new(tabwriter.Writer)
 	writer.Init(os.Stdout, 0, 8, 1, '\t', 0)
 
-	cap.TabWriter = writer
+	ctx.TabWriter = writer
 
-	listCommand := cap.NewCarinaCommand(writer, "list", "list swarm clusters")
+	listCommand := cap.NewCommand(ctx, "list", "list swarm clusters")
 	listCommand.Action(listCommand.List)
 
-	getCommand := cap.NewCarinaClusterCommand(writer, "get", "get information about a swarm cluster")
+	getCommand := cap.NewClusterCommand(ctx, "get", "get information about a swarm cluster")
 	getCommand.Action(getCommand.Get)
 
-	deleteCommand := cap.NewCarinaClusterCommand(writer, "delete", "delete a swarm cluster")
+	deleteCommand := cap.NewClusterCommand(ctx, "delete", "delete a swarm cluster")
 	deleteCommand.Action(deleteCommand.Delete)
 
-	createCommand := new(CarinaCreateCommand)
-	createCommand.CarinaClusterCommand = cap.NewCarinaClusterCommand(writer, "create", "create a swarm cluster")
+	createCommand := new(CreateCommand)
+	createCommand.ClusterCommand = cap.NewClusterCommand(ctx, "create", "create a swarm cluster")
 	createCommand.Flag("wait", "wait for swarm cluster completion").BoolVar(&createCommand.Wait)
 	createCommand.Flag("nodes", "number of nodes for the initial cluster").Default("1").IntVar(&createCommand.Nodes)
 	createCommand.Flag("autoscale", "whether autoscale is on or off").BoolVar(&createCommand.AutoScale)
 	createCommand.Action(createCommand.Create)
 
-	credentialsCommand := new(CarinaCredentialsCommand)
-	credentialsCommand.CarinaClusterCommand = cap.NewCarinaClusterCommand(writer, "credentials", "download credentials")
+	credentialsCommand := new(CredentialsCommand)
+	credentialsCommand.ClusterCommand = cap.NewClusterCommand(ctx, "credentials", "download credentials")
 	credentialsCommand.Flag("path", "path to write credentials out to").StringVar(&credentialsCommand.Path)
 	credentialsCommand.Action(credentialsCommand.Download)
 
 	growCommand := new(GrowCommand)
-	growCommand.CarinaClusterCommand = cap.NewCarinaClusterCommand(writer, "grow", "Grow a cluster by the requested number of nodes")
+	growCommand.ClusterCommand = cap.NewClusterCommand(ctx, "grow", "Grow a cluster by the requested number of nodes")
 	growCommand.Flag("nodes", "number of nodes to increase the cluster by").Required().IntVar(&growCommand.Nodes)
 	growCommand.Action(growCommand.Grow)
 
 	return cap
 }
 
-// NewCarinaCommand creates a command that relies on Auth
-func (app *CarinaApplication) NewCarinaCommand(writer *tabwriter.Writer, name, help string) *CarinaCommand {
-	carina := new(CarinaCommand)
-
+// NewCommand creates a command that relies on Auth
+func (app *Application) NewCommand(ctx *Context, name, help string) *Command {
+	carina := new(Command)
+	carina.Context = ctx
 	carina.CmdClause = app.Command(name, help)
-	carina.Flag("username", "Rackspace username").StringVar(&carina.Username)
-	carina.Flag("api-key", "Rackspace API Key").StringVar(&carina.APIKey)
-	carina.Flag("endpoint", "Carina API endpoint").Default(libcarina.BetaEndpoint).StringVar(&carina.Endpoint)
-
-	carina.PreAction(carina.Auth)
-
-	carina.TabWriter = new(tabwriter.Writer)
-	carina.TabWriter.Init(os.Stdout, 0, 8, 1, '\t', 0)
-
+	carina.PreAction(app.Auth)
 	return carina
 }
 
-// NewCarinaClusterCommand is a command that uses a cluster name
-func (app *CarinaApplication) NewCarinaClusterCommand(writer *tabwriter.Writer, name, help string) *CarinaClusterCommand {
-	cc := new(CarinaClusterCommand)
-	cc.CarinaCommand = app.NewCarinaCommand(writer, name, help)
+// NewClusterCommand is a command that uses a cluster name
+func (app *Application) NewClusterCommand(ctx *Context, name, help string) *ClusterCommand {
+	cc := new(ClusterCommand)
+	cc.Command = app.NewCommand(ctx, name, help)
 	cc.Arg("cluster-name", "name of the cluster").Required().StringVar(&cc.ClusterName)
 	return cc
 }
 
 // Auth does the authentication
-func (carina *CarinaCommand) Auth(pc *kingpin.ParseContext) (err error) {
+func (app *Application) Auth(pc *kingpin.ParseContext) (err error) {
+	carina := app.Context
+
 	userEnv := os.Getenv("RACKSPACE_USERNAME")
 	if userEnv != "" {
 		carina.Username = userEnv
@@ -172,8 +177,8 @@ func (carina *CarinaCommand) Auth(pc *kingpin.ParseContext) (err error) {
 }
 
 // List the current swarm clusters
-func (carina *CarinaCommand) List(pc *kingpin.ParseContext) (err error) {
-	clusterList, err := carina.ClusterClient.List()
+func (carina *Command) List(pc *kingpin.ParseContext) (err error) {
+	clusterList, err := carina.Context.ClusterClient.List()
 	if err != nil {
 		return err
 	}
@@ -188,38 +193,38 @@ func (carina *CarinaCommand) List(pc *kingpin.ParseContext) (err error) {
 	}
 	s := strings.Join(headerFields, "\t")
 
-	carina.TabWriter.Write([]byte(s + "\n"))
+	carina.Context.TabWriter.Write([]byte(s + "\n"))
 
 	for _, cluster := range clusterList {
-		writeCluster(carina.TabWriter, &cluster)
+		writeCluster(carina.Context.TabWriter, &cluster)
 	}
-	carina.TabWriter.Flush()
+	carina.Context.TabWriter.Flush()
 
 	return nil
 }
 
 // Get an individual cluster
-func (carina *CarinaClusterCommand) Get(pc *kingpin.ParseContext) (err error) {
-	cluster, err := carina.ClusterClient.Get(carina.ClusterName)
+func (carina *ClusterCommand) Get(pc *kingpin.ParseContext) (err error) {
+	cluster, err := carina.Context.ClusterClient.Get(carina.ClusterName)
 	if err == nil {
-		writeCluster(carina.TabWriter, cluster)
+		writeCluster(carina.Context.TabWriter, cluster)
 	}
-	carina.TabWriter.Flush()
+	carina.Context.TabWriter.Flush()
 	return err
 }
 
 // Delete a cluster
-func (carina *CarinaClusterCommand) Delete(pc *kingpin.ParseContext) (err error) {
-	cluster, err := carina.ClusterClient.Delete(carina.ClusterName)
+func (carina *ClusterCommand) Delete(pc *kingpin.ParseContext) (err error) {
+	cluster, err := carina.Context.ClusterClient.Delete(carina.ClusterName)
 	if err == nil {
-		writeCluster(carina.TabWriter, cluster)
+		writeCluster(carina.Context.TabWriter, cluster)
 	}
-	carina.TabWriter.Flush()
+	carina.Context.TabWriter.Flush()
 	return err
 }
 
 // Create a cluster
-func (carina *CarinaCreateCommand) Create(pc *kingpin.ParseContext) (err error) {
+func (carina *CreateCommand) Create(pc *kingpin.ParseContext) (err error) {
 	if carina.Nodes < 1 {
 		return errors.New("nodes must be >= 1")
 	}
@@ -232,14 +237,14 @@ func (carina *CarinaCreateCommand) Create(pc *kingpin.ParseContext) (err error) 
 		AutoScale:   carina.AutoScale,
 	}
 
-	cluster, err := carina.ClusterClient.Create(c)
+	cluster, err := carina.Context.ClusterClient.Create(c)
 
 	// Transitions past point of "new" or "building" are assumed to be states we
 	// can stop on.
 	if carina.Wait {
 		for cluster.Status == "new" || cluster.Status == "building" {
 			time.Sleep(13 * time.Second)
-			cluster, err = carina.ClusterClient.Get(carina.ClusterName)
+			cluster, err = carina.Context.ClusterClient.Get(carina.ClusterName)
 			if err != nil {
 				break
 			}
@@ -247,25 +252,25 @@ func (carina *CarinaCreateCommand) Create(pc *kingpin.ParseContext) (err error) 
 	}
 
 	if err == nil {
-		writeCluster(carina.TabWriter, cluster)
+		writeCluster(carina.Context.TabWriter, cluster)
 	}
-	carina.TabWriter.Flush()
+	carina.Context.TabWriter.Flush()
 	return err
 }
 
 // Grow increase the size of the given cluster
 func (carina *GrowCommand) Grow(pc *kingpin.ParseContext) (err error) {
-	cluster, err := carina.ClusterClient.Grow(carina.ClusterName, carina.Nodes)
+	cluster, err := carina.Context.ClusterClient.Grow(carina.ClusterName, carina.Nodes)
 	if err == nil {
-		writeCluster(carina.TabWriter, cluster)
+		writeCluster(carina.Context.TabWriter, cluster)
 	}
-	carina.TabWriter.Flush()
+	carina.Context.TabWriter.Flush()
 	return err
 }
 
 // Download credentials for a cluster
-func (carina *CarinaCredentialsCommand) Download(pc *kingpin.ParseContext) (err error) {
-	credentials, err := carina.ClusterClient.GetCredentials(carina.ClusterName)
+func (carina *CredentialsCommand) Download(pc *kingpin.ParseContext) (err error) {
+	credentials, err := carina.Context.ClusterClient.GetCredentials(carina.ClusterName)
 
 	p := path.Clean(carina.Path)
 
@@ -277,17 +282,17 @@ func (carina *CarinaCredentialsCommand) Download(pc *kingpin.ParseContext) (err 
 		return err
 	}
 
-	writeCredentials(carina.TabWriter, credentials, p)
+	writeCredentials(carina.Context.TabWriter, credentials, p)
 	// TODO: Handle Windows conditionally
 	fmt.Fprintf(os.Stdout, "source \"%v\"\n", path.Join(p, "docker.env"))
 	fmt.Fprintf(os.Stdout, "# Run the above or use a subshell with your arguments to %v\n", os.Args[0])
 	fmt.Fprintf(os.Stdout, "# $( %v command... ) \n", os.Args[0])
 
-	carina.TabWriter.Flush()
+	carina.Context.TabWriter.Flush()
 	return err
 }
 
 func main() {
-	app := NewCarina()
+	app := New()
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 }

--- a/main.go
+++ b/main.go
@@ -105,8 +105,8 @@ func New() *Application {
 
 	cap.PreAction(cap.Auth)
 
-	cap.Flag("username", "Rackspace username").StringVar(&ctx.Username)
-	cap.Flag("api-key", "Rackspace API Key").StringVar(&ctx.APIKey)
+	cap.Flag("username", "Rackspace username - can also set env var RACKSPACE_USERNAME").StringVar(&ctx.Username)
+	cap.Flag("api-key", "Rackspace API Key - can also set env var RACKSPACE_APIKEY").StringVar(&ctx.APIKey)
 	cap.Flag("endpoint", "Carina API endpoint").Default(libcarina.BetaEndpoint).StringVar(&ctx.Endpoint)
 
 	writer := new(tabwriter.Writer)


### PR DESCRIPTION
This improves the `--help` format and makes sure that auth happens within the main app itself before going to the follow on actions. API key is no longer shown (see https://github.com/alecthomas/kingpin/issues/70).

```
$ carina --help
usage: carina [<flags>] <command> [<args> ...]

command line interface to work with Docker Swarm clusters

Flags:
  --help               Show context-sensitive help (also try --help-long and --help-man).
  --username=USERNAME  Rackspace username
  --api-key=API-KEY    Rackspace API Key
  --endpoint="https://mycluster.rackspacecloud.com"
                       Carina API endpoint

Commands:
  help [<command>...]
    Show help.

  list
    list swarm clusters

  get <cluster-name>
    get information about a swarm cluster

  delete <cluster-name>
    delete a swarm cluster

  create [<flags>] <cluster-name>
    create a swarm cluster

  credentials [<flags>] <cluster-name>
    download credentials

  grow --nodes=NODES <cluster-name>
    Grow a cluster by the requested number of nodes
```
