### PR TITLE
Provide different instructions for Windows users.

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -273,10 +274,15 @@ func (carina *CredentialsCommand) Download(pc *kingpin.ParseContext) (err error)
 	}
 
 	writeCredentials(carina.TabWriter, credentials, p)
-	// TODO: Handle Windows conditionally
-	fmt.Fprintf(os.Stdout, "source \"%v\"\n", path.Join(p, "docker.env"))
-	fmt.Fprintf(os.Stdout, "# Run the above or eval a subshell with your arguments to %v\n", os.Args[0])
-	fmt.Fprintf(os.Stdout, "# eval \"$( %v command... )\" \n", os.Args[0])
+
+	if runtime.GOOS == "windows" {
+		fmt.Fprintf(os.Stdout, "\"%v\"\n", path.Join(p, "docker.cmd"))
+		fmt.Fprintf(os.Stdout, "# Run the above to set your docker environment\n")
+	} else {
+		fmt.Fprintf(os.Stdout, "source \"%v\"\n", path.Join(p, "docker.env"))
+		fmt.Fprintf(os.Stdout, "# Run the above or eval a subshell with your arguments to %v\n", os.Args[0])
+		fmt.Fprintf(os.Stdout, "# eval \"$( %v command... )\" \n", os.Args[0])
+	}
 
 	carina.TabWriter.Flush()
 	return err


### PR DESCRIPTION
Instead of defaulting to `bash` everywhere, this does some light casing on `runtime.GOOS` to choose what to output when the user gets credentials.

What do you think @carolynvs and @donschenck? I defaulted to `docker.cmd` even though `docker.ps1` is available.
