### PR TITLE
Versioning and build tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+
+go:
+  - 1.5
+
+script:
+  - make cross-build
+  - make carina
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ GOFILES = *.go version/*.go
 carina: $(GOFILES)
 	CGO_ENABLED=0 $(GOBUILD) -o carina .
 
+gocarina: $(GOFILES)
+	CGO_ENABLED=0 $(GOBUILD) -o ${GOPATH}/bin/carina .
+
 cross-build: carina linux darwin windows
 
 linux: bin/carina-linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ bin/carina-darwin-amd64: $(GOFILES)
 bin/carina.exe: $(GOFILES)
 	 CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ .
 
+test: carina
+	@echo "Tests are cool, we should do those."
+	carina --version
+
 .PHONY: clean
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,19 @@
-cross-build: linux darwin windows
+COMMIT = $(shell git rev-parse --verify HEAD)
+VERSION = $(shell git describe --tags --dirty='-dev' 2> /dev/null)
+GITHUB_ORG = rackerlabs
+GITHUB_REPO = carina
+XFLAG_PRE = -X github.com/${GITHUB_ORG}/${GITHUB_REPO}
+LDFLAGS = -w ${XFLAG_PRE}/version.Commit=${COMMIT} ${XFLAG_PRE}/version.Version=${VERSION}
+
+GOCMD = go
+GOBUILD = $(GOCMD) build -a -tags netgo -ldflags '$(LDFLAGS)'
+
+GOFILES = *.go version/*.go
+
+carina: $(GOFILES)
+	CGO_ENABLED=0 $(GOBUILD) -o carina .
+
+cross-build: carina linux darwin windows
 
 linux: bin/carina-linux-amd64
 
@@ -6,14 +21,14 @@ darwin: bin/carina-darwin-amd64
 
 windows: bin/carina.exe
 
-bin/carina-linux-amd64: main.go
-	 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo -ldflags '-w' -o bin/carina-linux-amd64 .
+bin/carina-linux-amd64: $(GOFILES)
+	 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ .
 
-bin/carina-darwin-amd64: main.go
-	 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -tags netgo -ldflags '-w' -o bin/carina-darwin-amd64 .
+bin/carina-darwin-amd64: $(GOFILES)
+	 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o $@ .
 
-bin/carina.exe: main.go
-	 CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -a -tags netgo -ldflags '-w' -o bin/carina.exe .
+bin/carina.exe: $(GOFILES)
+	 CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ .
 
 .PHONY: clean
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ There are downloads of the built binaries over on [releases](https://github.com/
 
 :warning: This is temporary tooling until we have integration into `rack` :warning:
 
+## Help
+
 ```
 $ carina --help-long
 usage: carina [<flags>] <command> [<args> ...]
@@ -58,3 +60,38 @@ Commands:
     --nodes=NODES  number of nodes to increase the cluster by
 
 ```
+
+## Building
+
+The build script assumes you're running go 1.5 or later. If not, upgrade or use
+something like [gimme](https://github.com/travis-ci/gimme).
+
+```bash
+make carina
+```
+
+This creates `carina` in the current directory (there is no `make install` currently).
+
+If you want it to build on prior releases of go, we'd need a PR to change up how
+the `Makefile` sets the `LDFLAGS` conditionally based on Go version.
+
+## Releasing
+
+### Prerequisites
+
+The release script relies on [github-release](https://github.com/aktau/github-release). Get it, configure it.
+
+Make sure you're on `master` then run `release.sh` with the next tag and release name.
+
+```bash
+./release.sh 0.2.0 "Acute Aquarius"
+```
+
+How do you pick the release name?
+
+### Naming things
+
+The hardest problem in computer science is picking names. For releases, we take
+an adjective attached combined with the next constellation from an
+[alphabetical list of constellations](http://www.astro.wisc.edu/~dolan/constellations/constellation_list.html).
+It can be alliterative if you like.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,39 @@
-# carina
+# Carina
 
 CLI tool for Carina, the [Rackspace container service](https://mycluster.rackspacecloud.com) that's currently in Beta.
 
 ![Carina Constellation](https://cloud.githubusercontent.com/assets/836375/10503963/e5bcca8c-72c0-11e5-8e14-2c1697297d7e.png)
 
-There are downloads of the built binaries over on [releases](https://github.com/rackerlabs/carina/releases).
-
 :warning: This is temporary tooling until we have integration into `rack` :warning:
 
-## Help
+## Installation
+
+There are downloads of the built binaries over in [releases](https://github.com/rackerlabs/carina/releases).
+
+After downloading the version for your system, you'll probably need to rename it,
+set it as executable, and put it on a `PATH` you have:
+
+### OS X
 
 ```
-$ carina --help-long
+$ mv carina-darwin-amd64 ~/bin/carina
+$ chmod u+x ~/bin/carina
+```
+
+### Linux
+
+```
+$ mv carina-linux-amd64 ~/bin/carina
+$ chmod u+x ~/bin/carina
+```
+
+### Windows
+
+TODO: Instructions for Windows. Care to add some?
+
+## Usage
+
+```
 usage: carina [<flags>] <command> [<args> ...]
 
 command line interface to launch and work with Docker Swarm clusters

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"runtime"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -287,14 +286,7 @@ func (carina *CredentialsCommand) Download(pc *kingpin.ParseContext) (err error)
 		return err
 	}
 
-	if runtime.GOOS == "windows" {
-		fmt.Fprintf(os.Stdout, "\"%v\"\n", path.Join(p, "docker.cmd"))
-		fmt.Fprintf(os.Stdout, "# Run the above to set your docker environment\n")
-	} else {
-		fmt.Fprintf(os.Stdout, "source \"%v\"\n", path.Join(p, "docker.env"))
-		fmt.Fprintf(os.Stdout, "# Run the above or eval a subshell with your arguments to %v\n", os.Args[0])
-		fmt.Fprintf(os.Stdout, "# eval \"$( %v command... )\" \n", os.Args[0])
-	}
+	fmt.Println(sourceHelpString(p, os.Args[0]))
 
 	err = carina.TabWriter.Flush()
 	return err

--- a/main.go
+++ b/main.go
@@ -92,6 +92,12 @@ func New() *Application {
 	writer := new(tabwriter.Writer)
 	writer.Init(os.Stdout, 0, 8, 1, '\t', 0)
 
+	// Make sure the tabwriter gets flushed at the end
+	app.Terminate(func(code int) {
+		ctx.TabWriter.Flush()
+		os.Exit(code)
+	})
+
 	ctx.TabWriter = writer
 
 	listCommand := cap.NewCommand(ctx, "list", "list swarm clusters")

--- a/main.go
+++ b/main.go
@@ -76,13 +76,13 @@ type GrowCommand struct {
 func New() *Application {
 
 	app := kingpin.New("carina", "command line interface to launch and work with Docker Swarm clusters")
+	app.Version(VersionString())
 
 	cap := new(Application)
 	ctx := new(Context)
 
 	cap.Application = app
 
-	cap.Version(version.Version)
 	cap.Context = ctx
 
 	cap.Flag("username", "Rackspace username - can also set env var RACKSPACE_USERNAME").OverrideDefaultFromEnvar("RACKSPACE_USERNAME").StringVar(&ctx.Username)
@@ -121,6 +121,14 @@ func New() *Application {
 	growCommand.Action(growCommand.Grow)
 
 	return cap
+}
+
+// VersionString returns the current version and commit of this binary (if set)
+func VersionString() string {
+	s := ""
+	s += fmt.Sprintf("Version: %s\n", version.Version)
+	s += fmt.Sprintf("Commit:  %s", version.Commit)
+	return s
 }
 
 // NewCommand creates a command wrapped with carina.Context

--- a/release.sh
+++ b/release.sh
@@ -11,8 +11,13 @@ declare -xr ORG="rackerlabs"
 declare -xr REPO="carina"
 declare -xr BINARY=$REPO
 
+# Pick your own leveled up tag
 TAG=${1}
+
+# Chosen from {adjective} {constellation}, where constellation comes from
+# http://www.astro.wisc.edu/~dolan/constellations/constellation_list.html
 NAME=${2}
+
 DESCRIPTION="Prototypal release of the Carina CLI"
 
 echo "Releasing '$TAG' - $NAME: $DESCRIPTION"

--- a/sourcing_nix.go
+++ b/sourcing_nix.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+	"path"
+)
+
+func sourceHelpString(basepath, carinaBinaryName string) string {
+	s := ""
+	s += fmt.Sprintf("source \"%v\"\n", path.Join(basepath, "docker.env"))
+	s += fmt.Sprintf("# Run the above or eval a subshell with your arguments to %v\n", carinaBinaryName)
+	s += fmt.Sprintf("# eval \"$( %v command... )\" \n", carinaBinaryName)
+	return s
+}

--- a/sourcing_windows.go
+++ b/sourcing_windows.go
@@ -1,0 +1,15 @@
+// +build windows
+
+package main
+
+import (
+	"fmt"
+	"path"
+)
+
+func sourceHelpString(basepath, carinaBinaryName string) string {
+	s := ""
+	s += fmt.Sprintf("\"%v\"\n", path.Join(basepath, "docker.cmd"))
+	s += fmt.Sprintf("# Run the above to set your docker environment\n")
+	return s
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,9 @@
+package version
+
+var (
+	// Version is the current CLI version
+	Version string
+
+	// Commit is the current commit this build comes from (if set)
+	Commit string
+)


### PR DESCRIPTION
- split unix and windows functionality into two distinct build setups
- fixed an issue where `Auth` was happening during `--version` and `--help`
- ensure `tabwriter` is always `Flush()`ed at the end
- provide some build and release docs in the README
