### PR TITLE
Write credentials to a directory named clusterName

### DIFF
--- a/main.go
+++ b/main.go
@@ -271,6 +271,10 @@ func (carina *CredentialsCommand) Download(pc *kingpin.ParseContext) (err error)
 		return err
 	}
 
+	if carina.Path == "" {
+		carina.Path = carina.ClusterName
+	}
+
 	p := path.Clean(carina.Path)
 
 	if p != "." {

--- a/sourcing_nix.go
+++ b/sourcing_nix.go
@@ -8,9 +8,11 @@ import (
 )
 
 func sourceHelpString(basepath, carinaBinaryName string) string {
-	s := ""
+	s := "#\n"
+	s += fmt.Sprintf("# Credentials written to %s/\n", basepath)
+	s += "#\n"
 	s += fmt.Sprintf("source \"%v\"\n", path.Join(basepath, "docker.env"))
-	s += fmt.Sprintf("# Run the above or eval a subshell with your arguments to %v\n", carinaBinaryName)
-	s += fmt.Sprintf("# eval \"$( %v command... )\" \n", carinaBinaryName)
+	s += fmt.Sprintf("# Run the command above or eval a subshell with your arguments to %v\n", carinaBinaryName)
+	s += fmt.Sprintf("#   eval \"$( %v command... )\"", carinaBinaryName)
 	return s
 }

--- a/sourcing_windows.go
+++ b/sourcing_windows.go
@@ -8,8 +8,10 @@ import (
 )
 
 func sourceHelpString(basepath, carinaBinaryName string) string {
-	s := ""
+	s := "#\n"
+	s += fmt.Sprintf("# Credentials written to %s/\n", basepath)
+	s += "#\n"
 	s += fmt.Sprintf("\"%v\"\n", path.Join(basepath, "docker.cmd"))
-	s += fmt.Sprintf("# Run the above to set your docker environment\n")
+	s += fmt.Sprintf("# Run the command above to set your docker environment")
 	return s
 }


### PR DESCRIPTION
Instead of...

> :tada: surprise here are credentials wherever you ran this :tada:

...we'll create the directory for users and list the sourcing line. 
