### PR TITLE
Write less fields out to users.

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,20 +166,7 @@ func (carina *Command) List(pc *kingpin.ParseContext) (err error) {
 		return err
 	}
 
-	headerFields := []string{
-		"ClusterName",
-		"Username",
-		"Flavor",
-		"Image",
-		"Nodes",
-		"Status",
-	}
-	s := strings.Join(headerFields, "\t")
-
-	_, err = carina.TabWriter.Write([]byte(s + "\n"))
-	if err != nil {
-		return err
-	}
+	writeClusterHeader(carina.TabWriter)
 
 	for _, cluster := range clusterList {
 		err = writeCluster(carina.TabWriter, &cluster)
@@ -311,13 +298,24 @@ func writeCredentials(w *tabwriter.Writer, creds *libcarina.Credentials, pth str
 
 func writeCluster(w *tabwriter.Writer, cluster *libcarina.Cluster) (err error) {
 	s := strings.Join([]string{cluster.ClusterName,
-		cluster.Username,
 		cluster.Flavor,
-		cluster.Image,
 		fmt.Sprintf("%v", cluster.Nodes),
 		cluster.Status}, "\t")
 	_, err = w.Write([]byte(s + "\n"))
 	return
+}
+
+func writeClusterHeader(w *tabwriter.Writer) (err error) {
+	headerFields := []string{
+		"ClusterName",
+		"Flavor",
+		"Nodes",
+		"Status",
+	}
+	s := strings.Join(headerFields, "\t")
+
+	_, err = w.Write([]byte(s + "\n"))
+	return err
 }
 
 func main() {


### PR DESCRIPTION
This trims some fields out. Reasoning:

Since the user should already know their `Username`, trim it out. Since `Image` isn't exposed as something they can specify with the tool, cut it out (it's also a nonsensical UUID to a random user).

This makes the output fit pretty nicely in the terminal too:

![screenshot 2015-10-16 14 21 26](https://cloud.githubusercontent.com/assets/836375/10551203/39072e66-7411-11e5-9b20-d478ffb9da48.png)

Requested by @simonjj.
