### PR TITLE
Isolated build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+bin
+carina
+
+builds.tgz
+
+# Keep .git, so that go get ./... works nicely
+# .git

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ _testmain.go
 
 bin/
 carina
+builds.tgz
 
 ca-key.pem
 ca.pem

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,5 +3,4 @@ FROM golang:1.5
 ADD . $GOPATH/src/github.com/rackerlabs/carina/
 WORKDIR $GOPATH/src/github.com/rackerlabs/carina/
 
-RUN make builds.tgz
-RUN cp builds.tgz /builds.tgz
+RUN make get-deps

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,7 @@
+FROM golang:1.5
+
+ADD . $GOPATH/src/github.com/rackerlabs/carina/
+WORKDIR $GOPATH/src/github.com/rackerlabs/carina/
+
+RUN make builds.tgz
+RUN cp builds.tgz /builds.tgz

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,14 @@ build-in-docker: Dockerfile.build
 	docker build -f Dockerfile.build -t carina-cli-build .
 	docker run --rm carina-cli-build cat /builds.tgz | tar xz
 
+tagged-build:
+	git checkout $(TAG)
+	make builds.tgz
+	cp builds.tgz /builds.tgz
+
+build-tagged-for-release:
+	docker run --rm carina-cli-build sh -c "make --quiet tagged-build TAG=${TAG} && cat /builds.tgz" | tar xz
+
 builds.tgz: cross-build
 	tar -cvzf builds.tgz bin/*
 
@@ -49,7 +57,7 @@ test: carina
 	@echo "Tests are cool, we should do those."
 	./carina --version
 
-.PHONY: clean
+.PHONY: clean build-in-docker build-tagged-for-release
 
 clean:
 	 rm -f bin/*

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,13 @@ gocarina: $(GOFILES)
 
 cross-build: get-deps carina linux darwin windows
 
+build-in-docker: Dockerfile.build
+	docker build -f Dockerfile.build -t carina-cli-build .
+	docker run --rm carina-cli-build cat /builds.tgz | tar xz
+
+builds.tgz: cross-build
+	tar -cvzf builds.tgz bin/*
+
 linux: bin/carina-linux-amd64
 
 darwin: bin/carina-darwin-amd64

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,11 @@ build-tagged-for-release: clean
 	mkdir -p bin/
 	docker cp carina-build:/built/bin .
 
-# This one is intended to be run inside the accompanying Docker container
-tagged-build:
+checkout-tag:
 	git checkout $(TAG)
-	make cross-build
+
+# This one is intended to be run inside the accompanying Docker container
+tagged-build: checkout-tag cross-build
 	./carina --version
 	mkdir -p /built/
 	cp -r bin /built/bin
@@ -60,7 +61,7 @@ test: carina
 	@echo "Tests are cool, we should do those."
 	./carina --version
 
-.PHONY: clean build-in-docker build-tagged-for-release
+.PHONY: clean build-tagged-for-release checkout tagged-build
 
 clean:
 	 rm -f bin/*

--- a/release.sh
+++ b/release.sh
@@ -49,7 +49,6 @@ github-release release \
 
 # Build with the tag now for actual binary shipping
 git pull release master
-git checkout "$TAG"
 make build-tagged-for-release TAG=$TAG
 
 github-release upload \

--- a/release.sh
+++ b/release.sh
@@ -37,7 +37,7 @@ echo "Releasing '$TAG' - $NAME: $DESCRIPTION"
 
 make clean
 # Build off master to make sure all is well
-make cross-build
+make build-in-docker
 
 github-release release \
   --user "$ORG" \
@@ -50,7 +50,7 @@ github-release release \
 # Build with the tag now for actual binary shipping
 git pull release master
 git checkout "$TAG"
-make cross-build
+make build-tagged-for-release TAG=$TAG
 
 github-release upload \
   --user "$ORG" \

--- a/release.sh
+++ b/release.sh
@@ -37,7 +37,11 @@ echo "Releasing '$TAG' - $NAME: $DESCRIPTION"
 
 make clean
 # Build off master to make sure all is well
-make build-in-docker
+make carina
+make test
+echo "Out with the old, in with the new"
+./carina --version
+echo "---------------------------------"
 
 github-release release \
   --user "$ORG" \


### PR DESCRIPTION
Took me a little while to get this under control. :tongue: 

This makes it so that the built binary doesn't leak out anything about a developer's setup. Not like it really mattered much (noticed it in a `panic` in #18). Also, the release build gets built in a clean environment, fresh from scratch, which also makes it nice to change tags on the inside for the releases.
