### PR TITLE
Docker carina

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,4 @@
 bin
-carina
-
 builds.tgz
 
 # Keep .git, so that go get ./... works nicely

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
-bin
-builds.tgz
-
 # Keep .git, so that go get ./... works nicely
 # .git
+
+# We build in the docker images for our release setup
+bin
+# We only include carina-linux when building the docker image itself
+carina

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ _testmain.go
 
 bin/
 carina
-builds.tgz
+carina-linux
 
 ca-key.pem
 ca.pem
@@ -34,3 +34,5 @@ key.pem
 docker.env
 docker.cmd
 docker.ps1
+
+ca-certificates.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM scratch
 # local carina must be the Linux binary, rely on the Makefile for this
-ADD bin/carina-linux-amd64 /carina
+ADD ca-certificates.crt /etc/ssl/certs/
+ADD carina-linux /carina
 ENTRYPOINT ["/carina"]
 CMD ["--version"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+# local carina must be the Linux binary, rely on the Makefile for this
+ADD bin/carina-linux-amd64 /carina
+ENTRYPOINT ["/carina"]
+CMD ["--version"]

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,34 @@ get-deps:
 carina: $(GOFILES)
 	CGO_ENABLED=0 $(GOBUILD) -o carina .
 
+carina-linux: linux
+	cp bin/carina-linux-amd64 carina-linux
+
+test: carina
+	@echo "Tests are cool, we should do those."
+	./carina --version
+
 gocarina: $(GOFILES)
 	CGO_ENABLED=0 $(GOBUILD) -o ${GOPATH}/bin/carina .
 
 cross-build: get-deps carina linux darwin windows
+
+linux: bin/carina-linux-amd64
+
+darwin: bin/carina-darwin-amd64
+
+windows: bin/carina.exe
+
+bin/carina-linux-amd64: $(GOFILES)
+ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ .
+
+bin/carina-darwin-amd64: $(GOFILES)
+ CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o $@ .
+
+bin/carina.exe: $(GOFILES)
+ CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ .
+
+############################ RELEASE TARGETS ############################
 
 build-tagged-for-release: clean
 	-docker rm -fv carina-build
@@ -42,24 +66,15 @@ tagged-build: checkout-tag cross-build
 	mkdir -p /built/
 	cp -r bin /built/bin
 
-linux: bin/carina-linux-amd64
+############################## DOCKER IMAGE ###############################
 
-darwin: bin/carina-darwin-amd64
+ca-certificates.crt:
+	-docker rm -fv carina-cert-grab
+	docker run --name carina-cert-grab ubuntu:15.04 sh -c "apt-get update -y && apt-get install ca-certificates -y"
+	docker cp carina-cert-grab:/etc/ssl/certs/ca-certificates.crt .
 
-windows: bin/carina.exe
-
-bin/carina-linux-amd64: $(GOFILES)
-	 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $@ .
-
-bin/carina-darwin-amd64: $(GOFILES)
-	 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o $@ .
-
-bin/carina.exe: $(GOFILES)
-	 CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GOBUILD) -o $@ .
-
-test: carina
-	@echo "Tests are cool, we should do those."
-	./carina --version
+carina/cli: ca-certificates.crt carina-linux
+	docker build -t carina/cli .
 
 .PHONY: clean build-tagged-for-release checkout tagged-build
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ cross-build: get-deps carina linux darwin windows
 
 build-tagged-for-release: clean
 	-docker rm -fv carina-build
-	docker build -f Dockerfile.build -t carina-cli-build .
+	docker build -f Dockerfile.build -t carina-cli-build --no-cache=true .
 	docker run --name carina-build carina-cli-build make tagged-build TAG=$(TAG)
 	mkdir -p bin/
 	docker cp carina-build:/built/bin .


### PR DESCRIPTION
This creates a Docker image for `carina`, named `carina/cli`. In order to make it able to connect to the carina endpoint, I had to add ca certificates to the `SCRATCH` image.
