### PR TITLE
Bash completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ carina-linux: linux
 
 test: carina
 	@echo "Tests are cool, we should do those."
-	./carina --bash-completion
+	eval "$( ./carina --bash-completion )"
 	./carina --version
 
 gocarina: $(GOFILES)

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ carina-linux: linux
 
 test: carina
 	@echo "Tests are cool, we should do those."
+	./carina --bash-completion
 	./carina --version
 
 gocarina: $(GOFILES)

--- a/main.go
+++ b/main.go
@@ -109,6 +109,8 @@ func New() *Application {
 		os.Exit(code)
 	})
 
+	cap.Flag("bash-completion", "Generate bash completion").Action(cap.generateBashCompletion).Hidden()
+
 	ctx.TabWriter = writer
 
 	createCommand := new(CreateCommand)
@@ -383,6 +385,14 @@ func writeClusterHeader(w *tabwriter.Writer) (err error) {
 
 	_, err = w.Write([]byte(s + "\n"))
 	return err
+}
+
+func (app *Application) generateBashCompletion(c *kingpin.ParseContext) error {
+	app.Writer(os.Stdout)
+	if err := app.UsageForContextWithTemplate(c, 2, BashCompletionTemplate); err != nil {
+		return err
+	}
+	return nil
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func New() *Application {
 		os.Exit(code)
 	})
 
-	cap.Flag("bash-completion", "Generate bash completion").Action(cap.generateBashCompletion).Hidden()
+	cap.Flag("bash-completion", "Generate bash completion").Action(cap.generateBashCompletion).Hidden().Bool()
 
 	ctx.TabWriter = writer
 
@@ -392,6 +392,7 @@ func (app *Application) generateBashCompletion(c *kingpin.ParseContext) error {
 	if err := app.UsageForContextWithTemplate(c, 2, BashCompletionTemplate); err != nil {
 		return err
 	}
+	os.Exit(0)
 	return nil
 }
 

--- a/templates.go
+++ b/templates.go
@@ -22,9 +22,9 @@ __kingpin_commands ()
   current_word="${COMP_WORDS[COMP_CWORD]}"
 
   COMMANDS='\
-    {{range .FlattenedCommands}}\
+    {{range .App.FlattenedCommands}}\
     {{if not .Hidden}}\
-      {{.FullCommand}}\
+{{.Name}}\
     {{end}}\
     {{end}}\
     '

--- a/templates.go
+++ b/templates.go
@@ -1,0 +1,75 @@
+package main
+
+// BashCompletionTemplate is a basic template we'll start off with
+var BashCompletionTemplate = `
+#!/usr/bin/env bash
+
+# bash completion for kingpin programs
+
+__kingpin_generate_completion()
+{
+  declare current_word
+  current_word="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=($(compgen -W "$1" -- "$current_word"))
+  return 0
+}
+
+__kingpin_commands ()
+{
+  declare current_word
+  declare command
+
+  current_word="${COMP_WORDS[COMP_CWORD]}"
+
+  COMMANDS='\
+    {{range .FlattenedCommands}}\
+    {{if not .Hidden}}\
+      {{.FullCommand}}\
+    {{end}}\
+    {{end}}\
+    '
+
+    if [ ${#COMP_WORDS[@]} == 4 ]; then
+
+      command="${COMP_WORDS[COMP_CWORD-2]}"
+      case "${command}" in
+      # If commands have subcommands
+      esac
+
+    else
+
+      case "${current_word}" in
+      -*)     __kingpin_options ;;
+      *)      __kingpin_generate_completion "$COMMANDS" ;;
+      esac
+
+    fi
+}
+
+__kingpin_options ()
+{
+  OPTIONS=''
+  __kingpin_generate_completion "$OPTIONS"
+}
+
+__kingpin ()
+{
+  declare previous_word
+  previous_word="${COMP_WORDS[COMP_CWORD-1]}"
+
+  case "$previous_word" in
+  *)              __kingpin_commands ;;
+  esac
+
+  return 0
+}
+
+# complete is a bash builtin, but recent versions of ZSH come with a function
+# called bashcompinit that will create a complete in ZSH. If the user is in
+# ZSH, load and run bashcompinit before calling the complete function.
+if [[ -n ${ZSH_VERSION-} ]]; then
+	autoload -U +X bashcompinit && bashcompinit
+fi
+
+complete -o default -o nospace -F __kingpin {{.App.Name}}
+`


### PR DESCRIPTION
Initial bash completion. I've also implemented this in https://github.com/alecthomas/kingpin/pull/76, but I wanted to take it for a spin with `carina` directly. It's only the top level commands right now, no flags.

```
$ carina [TAB]
create       credentials  delete       get          grow         help         list         rebuild
$ carina c[TAB]
$ carina cre[TAB][TAB]
create credentials
$ carina crea[TAB]
$ carina create
```
