### PR TITLE
Check latest

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
+	"unicode"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/blang/semver"
 	"github.com/getcarina/carina/version"
 	"github.com/getcarina/libcarina"
 )
@@ -194,30 +194,98 @@ func (app *Application) NewWaitClusterCommand(ctx *Context, name, help string) *
 const rackspaceUserNameEnvVar = "RACKSPACE_USERNAME"
 const rackspaceAPIKeyEnvVar = "RACKSPACE_APIKEY"
 
+type semver struct {
+	Major    int
+	Minor    int
+	Patch    int
+	Leftover string
+}
+
+func extractSemver(semi string) (*semver, error) {
+	var err error
+
+	if len(semi) < 5 { // 1.3.5
+		return nil, errors.New("Invalid semver")
+	}
+	// Allow a v in front
+	if semi[0] == 'v' {
+		semi = semi[1:]
+	}
+	semVerStrings := strings.SplitN(semi, ".", 3)
+
+	if len(semVerStrings) < 3 {
+		return nil, errors.New("Could not parse semver")
+	}
+
+	parsedSemver := new(semver)
+
+	digitError := errors.New("Could not parse digits of semver")
+	if parsedSemver.Major, err = strconv.Atoi(semVerStrings[0]); err != nil {
+		return nil, digitError
+	}
+	if parsedSemver.Minor, err = strconv.Atoi(semVerStrings[1]); err != nil {
+		return nil, digitError
+	}
+
+	var ps []rune
+
+	// Now to extract the patch and any follow on
+	for i, char := range semVerStrings[2] {
+		if !unicode.IsDigit(char) {
+			parsedSemver.Leftover = semVerStrings[2][i:]
+			break
+		}
+		ps = append(ps, char)
+	}
+
+	if parsedSemver.Patch, err = strconv.Atoi(string(ps)); err != nil {
+		return nil, digitError
+	}
+
+	return parsedSemver, nil
+
+}
+
+func (s *semver) Greater(s2 *semver) bool {
+	switch {
+	case s.Major == s2.Major && s.Minor == s2.Minor:
+		return s.Patch > s2.Patch
+	case s.Major == s2.Major:
+		return s.Minor > s2.Minor
+	}
+
+	return s.Major > s2.Major
+}
+
+func (s *semver) String() string {
+	return fmt.Sprintf("%d.%d.%d", s.Major, s.Minor, s.Patch)
+}
+
 func informLatest(pc *kingpin.ParseContext) error {
 	if strings.Contains(version.Version, "-dev") || version.Version == "" {
-		fmt.Fprintln(os.Stderr, "Assuming we're in dev mode, not checking for latest release")
+		fmt.Fprintln(os.Stderr, "# Assuming we're in dev mode, not checking for latest release")
 		return nil
 	}
-	fmt.Println(version.Version)
 
 	rel, err := version.LatestRelease()
 	if err != nil {
 		return fmt.Errorf("Unable to fetch information about the latest release of %s\n", os.Args[0])
 	}
-	fmt.Fprintf(os.Stderr, "Latest release: %s\n", *rel.TagName)
 
-	latest, err := semver.Make(*rel.TagName)
+	latest, err := extractSemver(*rel.TagName)
 	if err != nil {
-		return fmt.Errorf("Trouble parsing latest tag: %v\n", rel.TagName)
+		return fmt.Errorf("Trouble parsing latest tag (%v): %s\n", *rel.TagName, err)
 	}
-	current, err := semver.Make(version.Version)
+	current, err := extractSemver(version.Version)
 	if err != nil {
-		return fmt.Errorf("Trouble parsing current tag: %v\n", version.Version)
+		return fmt.Errorf("Trouble parsing current tag (%v): %s\n", version.Version, err)
 	}
 
-	fmt.Fprintf(os.Stderr, "%v\n", current)
-	fmt.Fprintf(os.Stderr, "%v\n", latest)
+	if latest.Greater(current) {
+		fmt.Fprintln(os.Stderr, "# A new version of the Carina client is out, go get it")
+		fmt.Fprintf(os.Stderr, "# You're on %v and the latest is %v\n", current, latest)
+		fmt.Fprintln(os.Stderr, "# https://github.com/getcarina/carina/releases ")
+	}
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -269,7 +269,7 @@ func informLatest(pc *kingpin.ParseContext) error {
 
 	rel, err := version.LatestRelease()
 	if err != nil {
-		return fmt.Errorf("Unable to fetch information about the latest release of %s\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "# Unable to fetch information about the latest release of %s\n. Continuing on.", os.Args[0])
 	}
 
 	latest, err := extractSemver(*rel.TagName)
@@ -282,9 +282,9 @@ func informLatest(pc *kingpin.ParseContext) error {
 	}
 
 	if latest.Greater(current) {
-		fmt.Fprintln(os.Stderr, "# A new version of the Carina client is out, go get it")
+		fmt.Fprintf(os.Stderr, "# A new version of the Carina client is out, go get it\n")
 		fmt.Fprintf(os.Stderr, "# You're on %v and the latest is %v\n", current, latest)
-		fmt.Fprintln(os.Stderr, "# https://github.com/getcarina/carina/releases ")
+		fmt.Fprintf(os.Stderr, "# https://github.com/getcarina/carina/releases\n")
 	}
 
 	return nil

--- a/version/releases.go
+++ b/version/releases.go
@@ -14,7 +14,7 @@ func LatestRelease() (*github.RepositoryRelease, error) {
 func latestRelease(owner, repo string) (*github.RepositoryRelease, error) {
 	client := github.NewClient(nil)
 
-	rel, resp, err := client.Repositories.GetLatestRelease(owner, repo)
+	rel, _, err := client.Repositories.GetLatestRelease(owner, repo)
 
 	if err != nil {
 		return nil, err

--- a/version/releases.go
+++ b/version/releases.go
@@ -1,0 +1,24 @@
+package version
+
+import "github.com/google/go-github/github"
+
+const ownerName = "getcarina"
+const repoName = "carina"
+
+// LatestRelease returns the most recent release of carina
+func LatestRelease() (*github.RepositoryRelease, error) {
+	return latestRelease(ownerName, repoName)
+}
+
+// Get the latest release currently
+func latestRelease(owner, repo string) (*github.RepositoryRelease, error) {
+	client := github.NewClient(nil)
+
+	rel, resp, err := client.Repositories.GetLatestRelease(owner, repo)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return rel, nil
+}


### PR DESCRIPTION
This checks to see what the latest release of the Carina CLI is, informing users to upgrade. We'll want to switch the suggested URL later.
