### PR TITLE
add carina env

### DIFF
--- a/credentials_nix.go
+++ b/credentials_nix.go
@@ -9,11 +9,11 @@ import (
 	"path"
 )
 
-func sourceHelpString(basepath string) string {
+func sourceHelpString(basepath string, name string) string {
 	s := "#\n"
 	s += fmt.Sprintf("# Credentials written to \"%s\"\n", basepath)
 	s += "#\n"
-	s += fmt.Sprintf("source \"%v\"\n", path.Join(basepath, "docker.env"))
+	s += fmt.Sprintf("eval `carina env %v`\n", name)
 	s += fmt.Sprintf("# Run the command above to get your Docker environment variables set\n")
 	return s
 }

--- a/credentials_windows.go
+++ b/credentials_windows.go
@@ -9,7 +9,7 @@ import (
 	"path"
 )
 
-func sourceHelpString(basepath string) string {
+func sourceHelpString(basepath string, name string) string {
 	s := "#\n"
 	s += fmt.Sprintf("# Credentials written to %s/\n", basepath)
 	s += "#\n"

--- a/main.go
+++ b/main.go
@@ -53,7 +53,8 @@ type CredentialsCommand struct {
 
 // EnvCommand keeps context about the cluster
 type EnvCommand struct {
-	*ClusterCommand
+	*Command
+	ClusterName string
 	Path string
 }
 
@@ -196,7 +197,10 @@ func (app *Application) NewCredentialsCommand(ctx *Context, name, help string) *
 // NewEnvCommand is a command that dumps out credentials to stdout
 func (app *Application) NewEnvCommand(ctx *Context, name, help string) *EnvCommand {
 	envCommand := new(EnvCommand)
-	envCommand.ClusterCommand = app.NewClusterCommand(ctx, name, help)
+	envCommand.Command = new(Command)
+	envCommand.Command.Context = ctx
+	envCommand.Command.CmdClause = app.Command(name, help)
+	envCommand.Arg("cluster-name", "name of the cluster").Required().StringVar(&envCommand.ClusterName)
 	return envCommand
 }
 

--- a/main.go
+++ b/main.go
@@ -484,7 +484,7 @@ func (carina *CredentialsCommand) Download(pc *kingpin.ParseContext) (err error)
 		return err
 	}
 
-	fmt.Fprintln(os.Stdout, sourceHelpString(p))
+	fmt.Fprintln(os.Stdout, sourceHelpString(p, carina.ClusterName))
 
 	err = carina.TabWriter.Flush()
 	return err


### PR DESCRIPTION
output is

```
source /path/to/cluster/docker.env
```

which enables

```
eval `carina env <cluster-name>`
```

So you don't need to type out / copy+paste the full path.
Requires `carina credentials` to have been run first. I would have made that implied when the credentials file is missing, but my gofu is weak.
