### PR TITLE
Download credentials on `env` if not available

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,7 +183,7 @@ func (app *Application) NewClusterCommand(ctx *Context, name, help string) *Clus
 func (app *Application) NewCredentialsCommand(ctx *Context, name, help string) *CredentialsCommand {
 	credentialsCommand := new(CredentialsCommand)
 	credentialsCommand.ClusterCommand = app.NewClusterCommand(ctx, name, help)
-	credentialsCommand.Flag("path", "path to write credentials out to").PlaceHolder("<cluster-name>").StringVar(&credentialsCommand.Path)
+	credentialsCommand.Flag("path", "path to read & write credentials").PlaceHolder("<cluster-name>").StringVar(&credentialsCommand.Path)
 	return credentialsCommand
 }
 

--- a/main.go
+++ b/main.go
@@ -332,11 +332,6 @@ func (carina *Command) Auth(pc *kingpin.ParseContext) (err error) {
 	return err
 }
 
-// NoAuth allows for overriding a PreAction to prevent auth when not necessary
-func (carina *Command) NoAuth(pc *kingpin.ParseContext) (err error) {
-	return
-}
-
 // List the current swarm clusters
 func (carina *Command) List(pc *kingpin.ParseContext) (err error) {
 	clusterList, err := carina.ClusterClient.List()

--- a/main.go
+++ b/main.go
@@ -141,10 +141,9 @@ func New() *Application {
 	credsCommand := cap.NewCredentialsCommand(ctx, "creds", "download credentials")
 	credsCommand.Action(credsCommand.Download).Hidden()
 
-	envCommand := cap.NewCredentialsCommand(ctx, "env", "show source command for setting credential environment."+
+	envCommand := cap.NewEnvCommand(ctx, "env", "show source command for setting credential environment."+
 		" Use with: eval `carina env <cluster-name>`")
 	envCommand.Action(envCommand.Show)
-	envCommand.PreAction(envCommand.NoAuth)
 
 	rebuildCommand := cap.NewWaitClusterCommand(ctx, "rebuild", "Rebuild a swarm cluster")
 	rebuildCommand.Action(rebuildCommand.Rebuild)
@@ -186,6 +185,19 @@ func (app *Application) NewCredentialsCommand(ctx *Context, name, help string) *
 	credentialsCommand.ClusterCommand = app.NewClusterCommand(ctx, name, help)
 	credentialsCommand.Flag("path", "path to read & write credentials").PlaceHolder("<cluster-name>").StringVar(&credentialsCommand.Path)
 	return credentialsCommand
+}
+
+// NewEnvCommand initializes a `carina env` command
+func (app *Application) NewEnvCommand(ctx *Context, name, help string) *CredentialsCommand {
+	envCommand := new(CredentialsCommand)
+	envCommand.ClusterCommand = new(ClusterCommand)
+	envCommand.Command = new(Command)
+	envCommand.Context = ctx
+	envCommand.CmdClause = app.Command(name, help)
+
+	envCommand.Arg("cluster-name", "name of the cluster").Required().StringVar(&envCommand.ClusterName)
+	envCommand.Flag("path", "path to read & write credentials").PlaceHolder("<cluster-name>").StringVar(&envCommand.Path)
+	return envCommand
 }
 
 // NewWaitClusterCommand is a command that uses a cluster name and allows the


### PR DESCRIPTION
~~Follow up to #52, relies on `NewCredentialsCommand` for building the context and help, followed by calling out to `carina.Download(pc)`.~~

~~One minor nit is that the help lists the path arg as "path to write credentials out to". Any idea what I should change this to or should we just have a separate setup for the env command (like before)?~~

This now creates a separate command that doesn't do `Auth` - no remote call to the API :bullettrain_side:. If the user doesn't have credentials downloaded, it will try to `Auth` then `Download`.

/cc @minrk 
