### PR TITLE
Cache the last update check.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ carina-linux: linux
 	cp bin/carina-linux-amd64 carina-linux
 
 test: carina
-	@echo "Tests are cool, we should do those."
+	go test -v
 	eval "$( ./carina --bash-completion )"
 	./carina --version
 

--- a/cache.go
+++ b/cache.go
@@ -32,6 +32,7 @@ func (cache *Cache) read() error {
 	}
 	err = json.NewDecoder(f).Decode(cache)
 	if err != nil {
+		_ = f.Close()
 		return err
 	}
 	err = f.Close()
@@ -45,8 +46,10 @@ func (cache *Cache) write() error {
 	if err != nil {
 		return err
 	}
+
 	err = json.NewEncoder(f).Encode(cache)
 	if err != nil {
+		_ = f.Close()
 		return err
 	}
 	err = f.Close()

--- a/cache.go
+++ b/cache.go
@@ -4,13 +4,14 @@ import (
 	"encoding/json"
 	"os"
 	"path"
+	"sync"
 	"time"
 )
 
 // Cache keeps track of last-check, also intended to cache tokens in the future
-// This is *NOT* thread safe and does not use any file locks
-// FIXME: Use locks for the library
+// Not all methods are thread safe and it does not use any file locks
 type Cache struct {
+	sync.Mutex
 	filename        string
 	LastUpdateCheck time.Time `json:"last-check"`
 }
@@ -72,6 +73,9 @@ func loadCache(filename string) (cache *Cache, err error) {
 }
 
 func (cache *Cache) updateLastCheck(t time.Time) error {
+	cache.Lock()
+	defer cache.Unlock()
+
 	err := cache.read()
 	if err != nil {
 		return err

--- a/cache.go
+++ b/cache.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"os"
 	"path"
 	"time"
@@ -23,9 +22,6 @@ func defaultCacheFilename() (string, error) {
 	}
 	return path.Join(bd, "cache.json"), nil
 }
-
-// ErrCacheNotExist informs about if the cache does not exist
-var ErrCacheNotExist = errors.New("Cache does not exist")
 
 // Read the on disk cache
 func (cache *Cache) read() error {

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path"
+	"time"
+)
+
+// Cache keeps track of last-check, also intended to cache tokens in the future
+type Cache struct {
+	filename        string
+	LastUpdateCheck time.Time `json:"last-check"`
+}
+
+func defaultCacheFilename() (string, error) {
+	bd, err := CarinaCredentialsBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(bd, "cache.json"), nil
+}
+
+// ErrCacheNotExist informs about if the cache does not exist
+var ErrCacheNotExist = errors.New("Cache does not exist")
+
+// LoadCache fetches the current state of the on disk cache
+func LoadCache(filename string) (cache *Cache, err error) {
+	cache = new(Cache)
+
+	cache.filename = filename
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = os.Stat(cache.filename)
+
+	if os.IsNotExist(err) {
+		return cache, ErrCacheNotExist
+	} else if err != nil {
+		return nil, err
+	}
+
+	f, err := os.OpenFile(cache.filename, os.O_RDONLY, 0666)
+	if err != nil {
+		return nil, err
+	}
+	err = json.NewDecoder(f).Decode(cache)
+	if err != nil {
+		return nil, err
+	}
+	err = f.Close()
+	return cache, err
+
+}
+
+func (cache *Cache) updateLastCheck(t time.Time) error {
+	cache.LastUpdateCheck = t
+	f, err := os.OpenFile(cache.filename, os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	err = json.NewEncoder(f).Encode(cache)
+	if err != nil {
+		return err
+	}
+	err = f.Close()
+	return err
+}
+
+func shouldCheckLatest() (bool, error) {
+	cacheName, err := defaultCacheFilename()
+	if err != nil {
+		return false, err
+	}
+
+	cache, err := LoadCache(cacheName)
+	if err == ErrCacheNotExist {
+		var f *os.File
+		f, err = os.Create(cacheName)
+		if err != nil {
+			return false, err
+		}
+		if err = f.Close(); err != nil {
+			return false, err
+		}
+	} else if err != nil {
+		return false, err
+	} else {
+		lastCheck := cache.LastUpdateCheck
+
+		// If we last checked `delay` ago, don't check again
+		if lastCheck.Add(12 * time.Hour).After(time.Now()) {
+			return false, nil
+		}
+	}
+
+	err = cache.updateLastCheck(time.Now())
+	return true, err
+}

--- a/cache.go
+++ b/cache.go
@@ -56,7 +56,8 @@ func (cache *Cache) write() error {
 	return err
 }
 
-func loadCache(filename string) (cache *Cache, err error) {
+// LoadCache retrieves the on disk cache and returns a cache struct
+func LoadCache(filename string) (cache *Cache, err error) {
 	cache = new(Cache)
 
 	cache.filename = filename
@@ -75,7 +76,8 @@ func loadCache(filename string) (cache *Cache, err error) {
 	return cache, cache.read()
 }
 
-func (cache *Cache) updateLastCheck(t time.Time) error {
+// UpdateLastCheck sets the last update time to t
+func (cache *Cache) UpdateLastCheck(t time.Time) error {
 	cache.Lock()
 	defer cache.Unlock()
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -40,7 +40,7 @@ func TestLoadCache(t *testing.T) {
 		}
 	}()
 
-	cache, err := loadCache(filename)
+	cache, err := LoadCache(filename)
 
 	if err != nil {
 		t.Errorf("Expected nil, got %v\n", err)
@@ -51,11 +51,11 @@ func TestLoadCache(t *testing.T) {
 
 	updateTime := time.Now()
 
-	err = cache.updateLastCheck(updateTime)
+	err = cache.UpdateLastCheck(updateTime)
 	if err != nil {
 		t.Fail()
 	}
-	newCache, err := loadCache(filename)
+	newCache, err := LoadCache(filename)
 	if err != nil {
 		t.Fail()
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -30,19 +30,17 @@ func randomName() string {
 
 func TestLoadCache(t *testing.T) {
 
-	noCache := fmt.Sprintf("carina-temp-cache-%s.json", randomName())
+	filename := fmt.Sprintf("carina-temp-cache-%s.json", randomName())
 
-	cache, err := loadCache(noCache)
-	if err != nil {
-		t.Errorf("Expected nil, got %v\n", err)
-	}
-	if cache.filename != noCache {
-		t.Errorf("Expected %v, got %v\n", noCache, cache.filename)
-	}
+	// Try to clean up as best we can
+	defer func() {
+		err := os.Remove(filename)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to remove temporary cache: %v\n", err)
+		}
+	}()
 
-	filename := noCache
-
-	cache, err = loadCache(filename)
+	cache, err := loadCache(filename)
 
 	if err != nil {
 		t.Errorf("Expected nil, got %v\n", err)
@@ -61,10 +59,8 @@ func TestLoadCache(t *testing.T) {
 	if err != nil {
 		t.Fail()
 	}
-	if updateTime != newCache.LastUpdateCheck {
+	if !updateTime.Equal(newCache.LastUpdateCheck) {
 		t.Errorf("Expected %v, got %v\n", updateTime, newCache.LastUpdateCheck)
 	}
-
-	os.Remove(filename)
 
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+var rand uint32
+var randmu sync.Mutex
+
+func reseed() uint32 {
+	return uint32(time.Now().UnixNano() + int64(os.Getpid()))
+}
+
+func randomName() string {
+	randmu.Lock()
+	r := rand
+	if r == 0 {
+		r = reseed()
+	}
+	r = r*1664525 + 1013904223 // constants from Numerical Recipes
+	rand = r
+	randmu.Unlock()
+	return strconv.Itoa(int(1e9 + r%1e9))[1:]
+}
+
+func TestLoadCache(t *testing.T) {
+
+	noCache := randomName()
+
+	cache, err := LoadCache(noCache)
+	if err != ErrCacheNotExist {
+		t.Errorf("Expected ErrCacheNotExist, got %v\n", err)
+	}
+	if cache.filename != noCache {
+		t.Errorf("Expected %v, got %v\n", noCache, cache.filename)
+	}
+
+	filename := noCache
+
+	cache, err = LoadCache(filename)
+
+	if err != ErrCacheNotExist {
+		t.Errorf("Expected ErrCacheNotExist, got %v\n", err)
+	}
+	if cache.filename != filename {
+		t.Errorf("Expected %v, got %v\n", filename, cache.filename)
+	}
+
+	updateTime := time.Now()
+
+	cache.updateLastCheck(updateTime)
+	newCache, err := LoadCache(filename)
+	if newCache.LastUpdateCheck != updateTime {
+		t.Errorf("Expected %v, got %v\n", updateTime, newCache.LastUpdateCheck)
+	}
+
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"sync"
@@ -29,11 +30,11 @@ func randomName() string {
 
 func TestLoadCache(t *testing.T) {
 
-	noCache := randomName()
+	noCache := fmt.Sprintf("carina-temp-cache-%s.json", randomName())
 
-	cache, err := LoadCache(noCache)
-	if err != ErrCacheNotExist {
-		t.Errorf("Expected ErrCacheNotExist, got %v\n", err)
+	cache, err := loadCache(noCache)
+	if err != nil {
+		t.Errorf("Expected nil, got %v\n", err)
 	}
 	if cache.filename != noCache {
 		t.Errorf("Expected %v, got %v\n", noCache, cache.filename)
@@ -41,21 +42,29 @@ func TestLoadCache(t *testing.T) {
 
 	filename := noCache
 
-	cache, err = LoadCache(filename)
+	cache, err = loadCache(filename)
 
-	if err != ErrCacheNotExist {
-		t.Errorf("Expected ErrCacheNotExist, got %v\n", err)
+	if err != nil {
+		t.Errorf("Expected nil, got %v\n", err)
 	}
-	if cache.filename != filename {
+	if filename != cache.filename {
 		t.Errorf("Expected %v, got %v\n", filename, cache.filename)
 	}
 
 	updateTime := time.Now()
 
-	cache.updateLastCheck(updateTime)
-	newCache, err := LoadCache(filename)
-	if newCache.LastUpdateCheck != updateTime {
+	err = cache.updateLastCheck(updateTime)
+	if err != nil {
+		t.Fail()
+	}
+	newCache, err := loadCache(filename)
+	if err != nil {
+		t.Fail()
+	}
+	if updateTime != newCache.LastUpdateCheck {
 		t.Errorf("Expected %v, got %v\n", updateTime, newCache.LastUpdateCheck)
 	}
+
+	os.Remove(filename)
 
 }

--- a/main.go
+++ b/main.go
@@ -285,9 +285,20 @@ func informLatest(pc *kingpin.ParseContext) error {
 		return err
 	}
 	cache, err := loadCache(cacheName)
+	if err != nil {
+		// TODO: If we fail, log it and keep on going
+		return nil
+	}
+	lastCheck := cache.LastUpdateCheck
 
-	check, err := cache.shouldCheckLatest()
-	if !check || err != nil {
+	// If we last checked `delay` ago, don't check again
+	if lastCheck.Add(12 * time.Hour).After(time.Now()) {
+		return nil
+	}
+
+	err = cache.updateLastCheck(time.Now())
+
+	if err != nil {
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -284,7 +284,7 @@ func shouldCheckForUpdate() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	cache, err := loadCache(cacheName)
+	cache, err := LoadCache(cacheName)
 	if err != nil {
 		// TODO: If we fail, log it and keep on going
 		return false, nil
@@ -296,7 +296,7 @@ func shouldCheckForUpdate() (bool, error) {
 		return false, nil
 	}
 
-	err = cache.updateLastCheck(time.Now())
+	err = cache.UpdateLastCheck(time.Now())
 
 	if err != nil {
 		return false, err

--- a/main.go
+++ b/main.go
@@ -529,7 +529,7 @@ func writeCredentials(w *tabwriter.Writer, creds *libcarina.Credentials, pth str
 }
 
 // Show echos the source command, for eval `carina env <name>`
-func (carina *CredentialsCommand) Show(pc *kingpin.ParseContext) (err error) {
+func (carina *CredentialsCommand) Show(pc *kingpin.ParseContext) error {
 	if carina.Path == "" {
 		baseDir, err := CarinaCredentialsBaseDir()
 		if err != nil {
@@ -539,7 +539,7 @@ func (carina *CredentialsCommand) Show(pc *kingpin.ParseContext) (err error) {
 	}
 
 	envPath := path.Join(carina.Path, "docker.env")
-	_, err = os.Stat(envPath)
+	_, err := os.Stat(envPath)
 	if os.IsNotExist(err) {
 		// Show is a NoAuth command, so we'll auth first for a download
 		err := carina.Auth(pc)

--- a/main.go
+++ b/main.go
@@ -280,7 +280,13 @@ func (s *semver) String() string {
 }
 
 func informLatest(pc *kingpin.ParseContext) error {
-	check, err := shouldCheckLatest()
+	cacheName, err := defaultCacheFilename()
+	if err != nil {
+		return err
+	}
+	cache, err := loadCache(cacheName)
+
+	check, err := cache.shouldCheckLatest()
 	if !check || err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -280,6 +280,11 @@ func (s *semver) String() string {
 }
 
 func informLatest(pc *kingpin.ParseContext) error {
+	check, err := shouldCheckLatest()
+	if !check || err != nil {
+		return err
+	}
+
 	if strings.Contains(version.Version, "-dev") || version.Version == "" {
 		fmt.Fprintln(os.Stderr, "# [WARN] In dev mode, not checking for latest release")
 		return nil
@@ -315,7 +320,9 @@ func informLatest(pc *kingpin.ParseContext) error {
 func (carina *Command) Auth(pc *kingpin.ParseContext) (err error) {
 
 	// Check for the latest release.
-	informLatest(pc)
+	if err = informLatest(pc); err != nil {
+		// Do nothing if the latest version couldn't be checked
+	}
 
 	if carina.Username == "" || carina.APIKey == "" {
 		// Backwards compatibility for prior releases, to be deprecated
@@ -462,7 +469,8 @@ func (carina *CredentialsCommand) Download(pc *kingpin.ParseContext) (err error)
 	}
 
 	if carina.Path == "" {
-		baseDir, err := CarinaCredentialsBaseDir()
+		var baseDir string
+		baseDir, err = CarinaCredentialsBaseDir()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This caches the last update check in a json file under `~/.carina/cache.json` (or wherever `CARINA_CREDENTIALS_DIR` is set). This could be/would be way simpler without all the filesystem error checks. :wink:

Follow up to #51.
