### PR TITLE
Cache token

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -13,7 +13,8 @@ import (
 type Cache struct {
 	sync.Mutex
 	filename        string
-	LastUpdateCheck time.Time `json:"last-check"`
+	LastUpdateCheck time.Time         `json:"last-check"`
+	Tokens          map[string]string `json:"tokens"`
 }
 
 func defaultCacheFilename() (string, error) {
@@ -59,6 +60,7 @@ func (cache *Cache) write() error {
 // LoadCache retrieves the on disk cache and returns a cache struct
 func LoadCache(filename string) (cache *Cache, err error) {
 	cache = new(Cache)
+	cache.Tokens = make(map[string]string)
 
 	cache.filename = filename
 	if err != nil {
@@ -86,5 +88,19 @@ func (cache *Cache) UpdateLastCheck(t time.Time) error {
 		return err
 	}
 	cache.LastUpdateCheck = t
+	return cache.write()
+}
+
+// SetToken sets the API token for a username in the cache
+func (cache *Cache) SetToken(username, token string) error {
+	cache.Lock()
+	defer cache.Unlock()
+
+	err := cache.read()
+	if err != nil {
+		return err
+	}
+
+	cache.Tokens[username] = token
 	return cache.write()
 }

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func New() *Application {
 	cap.Flag("username", "Carina username - can also set env var "+UserNameEnvVar).OverrideDefaultFromEnvar(UserNameEnvVar).StringVar(&ctx.Username)
 	cap.Flag("api-key", "Carina API Key - can also set env var "+APIKeyEnvVar).OverrideDefaultFromEnvar(APIKeyEnvVar).PlaceHolder(APIKeyEnvVar).StringVar(&ctx.APIKey)
 	cap.Flag("endpoint", "Carina API endpoint").Default(libcarina.BetaEndpoint).StringVar(&ctx.Endpoint)
-	cap.Flag("cache", "Cache API tokens and update times").Default("true").BoolVar(&ctx.CacheEnabled)
+	cap.Flag("cache", "Cache API tokens and update times; defaults to true, use --no-cache to turn off").Default("true").BoolVar(&ctx.CacheEnabled)
 
 	cap.PreAction(cap.InitCache)
 

--- a/main.go
+++ b/main.go
@@ -420,7 +420,7 @@ func dummyRequest(c *libcarina.ClusterClient) error {
 	resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("Invalid HEAD on %s", "/clusters"+c.Username)
+		return fmt.Errorf("Unable to auth on %s", "/clusters"+c.Username)
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func New() *Application {
 	cap.Flag("username", "Carina username - can also set env var "+UserNameEnvVar).OverrideDefaultFromEnvar(UserNameEnvVar).StringVar(&ctx.Username)
 	cap.Flag("api-key", "Carina API Key - can also set env var "+APIKeyEnvVar).OverrideDefaultFromEnvar(APIKeyEnvVar).PlaceHolder(APIKeyEnvVar).StringVar(&ctx.APIKey)
 	cap.Flag("endpoint", "Carina API endpoint").Default(libcarina.BetaEndpoint).StringVar(&ctx.Endpoint)
-	cap.Flag("cache", "Cache API tokens and update times").Default("false").BoolVar(&ctx.CacheEnabled)
+	cap.Flag("cache", "Cache API tokens and update times").Default("true").BoolVar(&ctx.CacheEnabled)
 
 	cap.PreAction(cap.InitCache)
 

--- a/main.go
+++ b/main.go
@@ -171,6 +171,15 @@ func VersionString() string {
 // InitCache sets up the cache for carina
 func (app *Application) InitCache(pc *kingpin.ParseContext) error {
 	if app.CacheEnabled {
+		bd, err := CarinaCredentialsBaseDir()
+		if err != nil {
+			return err
+		}
+		err = os.MkdirAll(bd, 0777)
+		if err != nil {
+			return err
+		}
+
 		cacheName, err := defaultCacheFilename()
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -409,8 +409,7 @@ func (carina *Command) Auth(pc *kingpin.ParseContext) (err error) {
 	if err != nil {
 		return err
 	}
-	carina.Cache.SetToken(carina.Username, carina.ClusterClient.Token)
-
+	err = carina.Cache.SetToken(carina.Username, carina.ClusterClient.Token)
 	return err
 }
 
@@ -426,7 +425,7 @@ func dummyRequest(c *libcarina.ClusterClient) error {
 	if err != nil {
 		return err
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("Unable to auth on %s", "/clusters"+c.Username)

--- a/main.go
+++ b/main.go
@@ -410,7 +410,7 @@ func dummyRequest(c *libcarina.ClusterClient) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("User-Agent", "carina dummy request")
+	req.Header.Set("User-Agent", "getcarina/carina dummy request")
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("X-Auth-Token", c.Token)
 	resp, err := c.Client.Do(req)


### PR DESCRIPTION
This caches tokens directly.

I'm not sure how to use a token in a fail-safe way that would try to reach the service using the cached token, and if it fails, gets a new token from identity.
