### PR TITLE
Rm actual files

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -499,9 +500,9 @@ func (carina *CredentialsCommand) Delete(pc *kingpin.ParseContext) (err error) {
 		return err
 	}
 
-	// TODO: Any other failsafes we should check here?
-	if p == "" || p == "/" {
-		return errors.New("Path to cluster is empty or a root path, not deleting")
+	p = filepath.Clean(p)
+	if p == "" || p == "." || p == "/" {
+		return errors.New("Path to cluster is empty, the current directory, or a root path, not deleting")
 	}
 
 	_, statErr := os.Stat(p)

--- a/main.go
+++ b/main.go
@@ -504,7 +504,17 @@ func (carina *CredentialsCommand) Delete(pc *kingpin.ParseContext) (err error) {
 		return errors.New("Path to cluster is empty or a root path, not deleting")
 	}
 
-	// TODO: Check that the path exists along with the docker.env
+	_, statErr := os.Stat(p)
+	if os.IsNotExist(statErr) {
+		// Assume credentials were never on disk
+		return nil
+	}
+
+	// If the path exists but not the actual credentials, inform user
+	_, statErr = os.Stat(path.Join(p, "ca.pem"))
+	if os.IsNotExist(statErr) {
+		return errors.New("Path to cluster credentials exists but not the ca.pem, not deleting. Remove by hand.")
+	}
 
 	err = os.RemoveAll(p)
 	return err


### PR DESCRIPTION
Adds support for `carina rm`, which is the same as `carina delete` but matches `docker` parlance.

Deletes the credentials on disk if possible. Solves #64 

Check it out @carolynvs!
