### PR TITLE
Use a CARINA_HOME environment variable.

### DIFF
--- a/credentials_nix.go
+++ b/credentials_nix.go
@@ -35,6 +35,9 @@ func userHomeDir() (string, error) {
 
 // CarinaCredentialsBaseDir get the current base directory for carina credentials
 func CarinaCredentialsBaseDir() (string, error) {
+	if os.Getenv(CarinaHomeDirEnvVar) != "" {
+		return os.Getenv(CarinaHomeDirEnvVar), nil
+	}
 	if os.Getenv(CredentialsBaseDirEnvVar) != "" {
 		return os.Getenv(CredentialsBaseDirEnvVar), nil
 	}

--- a/credentials_windows.go
+++ b/credentials_windows.go
@@ -31,6 +31,9 @@ func userHomeDir() (string, error) {
 
 // CarinaCredentialsBaseDir get the current base directory for carina credentials
 func CarinaCredentialsBaseDir() (string, error) {
+	if os.Getenv(CarinaHomeDirEnvVar) != "" {
+		return os.Getenv(CarinaHomeDirEnvVar), nil
+	}
 	if os.Getenv(CredentialsBaseDirEnvVar) != "" {
 		return os.Getenv(CredentialsBaseDirEnvVar), nil
 	}

--- a/main.go
+++ b/main.go
@@ -595,6 +595,9 @@ func (carina *WaitClusterCommand) clusterApplyWait(op clusterOp) (err error) {
 // CredentialsBaseDirEnvVar environment variable name for where credentials are downloaded to by default
 const CredentialsBaseDirEnvVar = "CARINA_CREDENTIALS_DIR"
 
+// CarinaHomeDirEnvVar is the environment variable name for carina data, config, etc.
+const CarinaHomeDirEnvVar = "CARINA_HOME"
+
 // Create a cluster
 func (carina *CreateCommand) Create(pc *kingpin.ParseContext) (err error) {
 	return carina.clusterApplyWait(func(clusterName string) (*libcarina.Cluster, error) {


### PR DESCRIPTION
`CARINA_CREDENTIALS_DIR` is way too long and we're using the same directory for the API token cache as well (it was confusing).
