### PR TITLE
Docker semantics

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,11 +130,14 @@ func New() *Application {
 	getCommand := cap.NewWaitClusterCommand(ctx, "get", "Get information about a swarm cluster")
 	getCommand.Action(getCommand.Get)
 
-	listCommand := cap.NewCommand(ctx, "list", "List swarm clusters")
-	listCommand.Action(listCommand.List)
+	inspectCommand := cap.NewWaitClusterCommand(ctx, "inspect", "Get information about a swarm cluster")
+	inspectCommand.Action(inspectCommand.Get).Hidden()
 
 	lsCommand := cap.NewCommand(ctx, "ls", "List swarm clusters")
-	lsCommand.Action(lsCommand.List).Hidden()
+	lsCommand.Action(lsCommand.List)
+
+	listCommand := cap.NewCommand(ctx, "list", "List swarm clusters")
+	listCommand.Action(listCommand.List).Hidden()
 
 	growCommand := new(GrowCommand)
 	growCommand.ClusterCommand = cap.NewClusterCommand(ctx, "grow", "Grow a cluster by the requested number of nodes")
@@ -149,16 +152,17 @@ func New() *Application {
 	credsCommand.Action(credsCommand.Download).Hidden()
 
 	envCommand := cap.NewEnvCommand(ctx, "env", "show source command for setting credential environment."+
-		" Use with: eval `carina env <cluster-name>`")
+		" Use with: eval \"$( carina env <cluster-name> )\"")
 	envCommand.Action(envCommand.Show)
 
 	rebuildCommand := cap.NewWaitClusterCommand(ctx, "rebuild", "Rebuild a swarm cluster")
 	rebuildCommand.Action(rebuildCommand.Rebuild)
 
-	deleteCommand := cap.NewCredentialsCommand(ctx, "delete", "Delete a swarm cluster")
-	deleteCommand.Action(deleteCommand.Delete)
 	rmCommand := cap.NewCredentialsCommand(ctx, "rm", "Remove a swarm cluster")
 	rmCommand.Action(rmCommand.Delete)
+
+	deleteCommand := cap.NewCredentialsCommand(ctx, "delete", "Delete a swarm cluster")
+	deleteCommand.Action(deleteCommand.Delete).Hidden()
 
 	return cap
 }

--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ func New() *Application {
 
 	growCommand := new(GrowCommand)
 	growCommand.ClusterCommand = cap.NewClusterCommand(ctx, "grow", "Grow a cluster by the requested number of nodes")
-	growCommand.Flag("nodes", "number of nodes to increase the cluster by").Required().IntVar(&growCommand.Nodes)
+	growCommand.Flag("by", "number of nodes to increase the cluster by").Required().IntVar(&growCommand.Nodes)
 	growCommand.Action(growCommand.Grow)
 
 	credentialsCommand := cap.NewCredentialsCommand(ctx, "credentials", "download credentials")


### PR DESCRIPTION
## `carina inspect <clustername>`

This is the same as `carina get`, mirroring `docker inspect`.
## `carina ls`

This was already in before, now it's being shown in the help while `carina list` is still available while hidden.
## `carina grow <clustername> --by 2`

The flag for growth is now `by` instead of `nodes`. This is backwards incompatible with previous clients.
