### PR TITLE
Windows experience

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"os"
-	"path"
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -22,7 +22,7 @@ func defaultCacheFilename() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return path.Join(bd, "cache.json"), nil
+	return filepath.Join(bd, "cache.json"), nil
 }
 
 // Read the on disk cache

--- a/credentials_nix.go
+++ b/credentials_nix.go
@@ -6,15 +6,17 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"path"
+	"path/filepath"
 )
 
-func sourceHelpString(basepath string, name string) string {
-	s := "#\n"
-	s += fmt.Sprintf("# Credentials written to \"%s\"\n", basepath)
-	s += "#\n"
-	s += fmt.Sprintf("eval `carina env %v`\n", name)
-	s += fmt.Sprintf("# Run the command above to get your Docker environment variables set\n")
+func getCredentialFilePath(basepath string, shell string) string {
+	return filepath.Join(basepath, "docker.env")
+}
+
+func sourceHelpString(credentialFile string, clusterName string, shell string) string {
+	s := fmt.Sprintf("source %s\n", credentialFile)
+	s += fmt.Sprintf("# Run the command below to get your Docker environment variables set:\n")
+	s += fmt.Sprintf("# eval $(carina env %s)", clusterName)
 	return s
 }
 
@@ -44,12 +46,12 @@ func CarinaCredentialsBaseDir() (string, error) {
 
 	// Support XDG
 	if os.Getenv(xdgDataHomeEnvVar) != "" {
-		return path.Join(os.Getenv(xdgDataHomeEnvVar), defaultNonDotDir), nil
+		return filepath.Join(os.Getenv(xdgDataHomeEnvVar), defaultNonDotDir), nil
 	}
 
 	homeDir, err := userHomeDir()
 	if err != nil {
 		return "", err
 	}
-	return path.Join(homeDir, defaultDotDir), nil
+	return filepath.Join(homeDir, defaultDotDir), nil
 }

--- a/credentials_nix.go
+++ b/credentials_nix.go
@@ -9,6 +9,10 @@ import (
 	"path/filepath"
 )
 
+func credentialsNextStepsString(clusterName string) string {
+	return fmt.Sprintf("To see how to connect to your cluster, run: carina env %s\n", clusterName)
+}
+
 func getCredentialFilePath(basepath string, shell string) string {
 	return filepath.Join(basepath, "docker.env")
 }

--- a/credentials_nix.go
+++ b/credentials_nix.go
@@ -10,7 +10,7 @@ import (
 )
 
 func credentialsNextStepsString(clusterName string) string {
-	return fmt.Sprintf("To see how to connect to your cluster, run: carina env %s\n", clusterName)
+	return fmt.Sprintf("# To see how to connect to your cluster, run: carina env %s\n", clusterName)
 }
 
 func getCredentialFilePath(basepath string, shell string) string {

--- a/credentials_windows.go
+++ b/credentials_windows.go
@@ -6,21 +6,43 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 )
 
-func sourceHelpString(basepath string, name string) string {
-	s := "#\n"
-	s += fmt.Sprintf("# Credentials written to %s/\n", basepath)
-	s += "#\n"
-	s += fmt.Sprintf("\"%v\"\n", path.Join(basepath, "docker.cmd"))
-	s += fmt.Sprintf("# Run the command above to set your docker environment")
-	return s
+func getCredentialFilePath(basepath string, shell string) string {
+	switch shell {
+	case "powershell":
+		return filepath.Join(basepath, "docker.ps1")
+	case "cmd":
+		return filepath.Join(basepath, "docker.cmd")
+	default:
+		return filepath.Join(basepath, "docker.env")
+	}
+}
+
+func sourceHelpString(credentialFile string, clusterName string, shell string) string {
+	switch shell {
+	case "powershell":
+		s := fmt.Sprintf(". %s\n", credentialFile)
+		s += fmt.Sprintf("# Run the command below to get your Docker environment variables set:\n")
+		s += fmt.Sprintf("# carina env %s --shell powershell | iex", clusterName) // PowerShell bombs if you have an empty line, leaving out
+		return s
+	case "cmd":
+		s := fmt.Sprintf("CALL %s\n", credentialFile)
+		s += fmt.Sprintf("# Run the command below to get your Docker environment variables set:\n")
+		s += fmt.Sprint("# copy and paste the above command into your command prompt\n")
+		return s
+	default:
+		s := fmt.Sprintf("source %s\n", credentialFile)
+		s += fmt.Sprintf("# Run the command below to get your Docker environment variables set:\n")
+		s += fmt.Sprintf("# eval $(carina env %s)\n", clusterName)
+		return s
+	}
 }
 
 func userHomeDir() (string, error) {
 	if os.Getenv("HOMEDRIVE") != "" && os.Getenv("HOMEPATH") != "" {
-		return path.Join(os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH")), nil
+		return filepath.Join(os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH")), nil
 	}
 	if os.Getenv("HOME") != "" {
 		return os.Getenv("HOME"), nil
@@ -42,5 +64,5 @@ func CarinaCredentialsBaseDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return path.Join(homeDir, "carina"), nil
+	return filepath.Join(homeDir, "carina"), nil
 }

--- a/credentials_windows.go
+++ b/credentials_windows.go
@@ -11,7 +11,7 @@ import (
 )
 
 func credentialsNextStepsString(clusterName string) string {
-	return fmt.Sprintf("To see how to connect to your cluster, run: carina env %s --shell cmd|powershell|bash\n", clusterName)
+	return fmt.Sprintf("# To see how to connect to your cluster, run: carina env %s --shell cmd|powershell|bash\n", clusterName)
 }
 
 func getCredentialFilePath(basepath string, shell string) string {

--- a/credentials_windows.go
+++ b/credentials_windows.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func credentialsNextStepsString(clusterName string) string {
@@ -19,9 +20,17 @@ func getCredentialFilePath(basepath string, shell string) string {
 		return filepath.Join(basepath, "docker.ps1")
 	case "cmd":
 		return filepath.Join(basepath, "docker.cmd")
-	default:
+	default: // Windows Bash
 		return filepath.Join(basepath, "docker.env")
 	}
+}
+
+func forceUnixPath(winPath string) string {
+	// Convert C:/ --> /C/
+	unixPath := "/" + strings.Replace(winPath, ":\\", "/", 1)
+	// Replace path seperators
+	unixPath = strings.Replace(unixPath, "\\", "/", -1)
+	return unixPath
 }
 
 func sourceHelpString(credentialFile string, clusterName string, shell string) string {
@@ -36,8 +45,8 @@ func sourceHelpString(credentialFile string, clusterName string, shell string) s
 		s += fmt.Sprintf("# Run the command below to get your Docker environment variables set:\n")
 		s += fmt.Sprint("# copy and paste the above command into your command prompt\n")
 		return s
-	default:
-		s := fmt.Sprintf("source %s\n", credentialFile)
+	default: // Windows Bash
+		s := fmt.Sprintf("source %s\n", forceUnixPath(credentialFile))
 		s += fmt.Sprintf("# Run the command below to get your Docker environment variables set:\n")
 		s += fmt.Sprintf("# eval $(carina env %s)\n", clusterName)
 		return s

--- a/credentials_windows.go
+++ b/credentials_windows.go
@@ -41,9 +41,8 @@ func sourceHelpString(credentialFile string, clusterName string, shell string) s
 		s += fmt.Sprintf("# carina env %s --shell powershell | iex", clusterName) // PowerShell bombs if you have an empty line, leaving out
 		return s
 	case "cmd":
-		s := fmt.Sprintf("CALL %s\n", credentialFile)
-		s += fmt.Sprintf("# Run the command below to get your Docker environment variables set:\n")
-		s += fmt.Sprint("# copy and paste the above command into your command prompt\n")
+		s := fmt.Sprintf("# Run the command below to get your Docker environment variables set:\n")
+		s += fmt.Sprintf("CALL %s\n", credentialFile)
 		return s
 	default: // Windows Bash
 		s := fmt.Sprintf("source %s\n", forceUnixPath(credentialFile))

--- a/credentials_windows.go
+++ b/credentials_windows.go
@@ -9,6 +9,10 @@ import (
 	"path/filepath"
 )
 
+func credentialsNextStepsString(clusterName string) string {
+	return fmt.Sprintf("To see how to connect to your cluster, run: carina env %s --shell cmd|powershell|bash\n", clusterName)
+}
+
 func getCredentialFilePath(basepath string, shell string) string {
 	switch shell {
 	case "powershell":

--- a/main.go
+++ b/main.go
@@ -660,10 +660,10 @@ func (carina *CredentialsCommand) Download(pc *kingpin.ParseContext) (err error)
 	}
 
 	if !carina.Silent {
-		fmt.Println("")
-		fmt.Printf("Credentials written to \"%s\"\n", p)
+		fmt.Println("#")
+		fmt.Printf("# Credentials written to \"%s\"\n", p)
 		fmt.Print(credentialsNextStepsString(carina.ClusterName))
-		fmt.Println("")
+		fmt.Println("#")
 	}
 
 	err = carina.TabWriter.Flush()

--- a/main.go
+++ b/main.go
@@ -657,11 +657,10 @@ func (carina *CredentialsCommand) Download(pc *kingpin.ParseContext) (err error)
 		return err
 	}
 
-	fmt.Println("#")
-	fmt.Printf("# Credentials written to \"%s\"\n", p)
-	fmt.Println("#")
-	envPath := getCredentialFilePath(carina.Path)
-	fmt.Println(sourceHelpString(envPath, carina.ClusterName))
+	fmt.Println("")
+	fmt.Printf("Credentials written to \"%s\"\n", p)
+	fmt.Printf("To see how to connect to your cluster, run: carina env %s\n", carina.ClusterName)
+	fmt.Println("")
 
 	err = carina.TabWriter.Flush()
 	return err

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -53,6 +52,12 @@ type ClusterCommand struct {
 type CredentialsCommand struct {
 	*ClusterCommand
 	Path string
+}
+
+// ShellCommand keeps context about the currently executing shell
+type ShellCommand struct {
+	*CredentialsCommand
+	Shell string
 }
 
 // WaitClusterCommand is simply a ClusterCommand that waits for cluster creation
@@ -151,8 +156,7 @@ func New() *Application {
 	credsCommand := cap.NewCredentialsCommand(ctx, "creds", "download credentials")
 	credsCommand.Action(credsCommand.Download).Hidden()
 
-	envCommand := cap.NewEnvCommand(ctx, "env", "show source command for setting credential environment."+
-		" Use with: eval \"$( carina env <cluster-name> )\"")
+	envCommand := cap.NewEnvCommand(ctx, "env", "show source command for setting credential environment")
 	envCommand.Action(envCommand.Show)
 
 	rebuildCommand := cap.NewWaitClusterCommand(ctx, "rebuild", "Rebuild a swarm cluster")
@@ -223,15 +227,10 @@ func (app *Application) NewCredentialsCommand(ctx *Context, name, help string) *
 }
 
 // NewEnvCommand initializes a `carina env` command
-func (app *Application) NewEnvCommand(ctx *Context, name, help string) *CredentialsCommand {
-	envCommand := new(CredentialsCommand)
-	envCommand.ClusterCommand = new(ClusterCommand)
-	envCommand.Command = new(Command)
-	envCommand.Context = ctx
-	envCommand.CmdClause = app.Command(name, help)
-
-	envCommand.Arg("cluster-name", "name of the cluster").Required().StringVar(&envCommand.ClusterName)
-	envCommand.Flag("path", "path to read & write credentials").PlaceHolder("<cluster-name>").StringVar(&envCommand.Path)
+func (app *Application) NewEnvCommand(ctx *Context, name, help string) *ShellCommand {
+	envCommand := new(ShellCommand)
+	envCommand.CredentialsCommand = app.NewCredentialsCommand(ctx, name, help)
+	envCommand.Flag("shell", "Force environment to be configured for specified shell").StringVar(&envCommand.Shell)
 	return envCommand
 }
 
@@ -516,7 +515,7 @@ func (carina *CredentialsCommand) Delete(pc *kingpin.ParseContext) (err error) {
 	}
 
 	// If the path exists but not the actual credentials, inform user
-	_, statErr = os.Stat(path.Join(p, "ca.pem"))
+	_, statErr = os.Stat(filepath.Join(p, "ca.pem"))
 	if os.IsNotExist(statErr) {
 		return errors.New("Path to cluster credentials exists but not the ca.pem, not deleting. Remove by hand.")
 	}
@@ -627,10 +626,10 @@ func (carina *CredentialsCommand) clusterPath() (p string, err error) {
 		if err != nil {
 			return "", err
 		}
-		carina.Path = path.Join(baseDir, clusterDirName, carina.Username, carina.ClusterName)
+		carina.Path = filepath.Join(baseDir, clusterDirName, carina.Username, carina.ClusterName)
 	}
 
-	p = path.Clean(carina.Path)
+	p = filepath.Clean(carina.Path)
 	return p, err
 }
 
@@ -658,7 +657,11 @@ func (carina *CredentialsCommand) Download(pc *kingpin.ParseContext) (err error)
 		return err
 	}
 
-	fmt.Fprintln(os.Stdout, sourceHelpString(p, carina.ClusterName))
+	fmt.Println("#")
+	fmt.Printf("# Credentials written to \"%s\"\n", p)
+	fmt.Println("#")
+	envPath := getCredentialFilePath(carina.Path)
+	fmt.Println(sourceHelpString(envPath, carina.ClusterName))
 
 	err = carina.TabWriter.Flush()
 	return err
@@ -667,7 +670,7 @@ func (carina *CredentialsCommand) Download(pc *kingpin.ParseContext) (err error)
 func writeCredentials(w *tabwriter.Writer, creds *libcarina.Credentials, pth string) (err error) {
 	// TODO: Prompt when file already exists?
 	for fname, b := range creds.Files {
-		p := path.Join(pth, fname)
+		p := filepath.Join(pth, fname)
 		err = ioutil.WriteFile(p, b, 0600)
 		if err != nil {
 			return err
@@ -678,16 +681,16 @@ func writeCredentials(w *tabwriter.Writer, creds *libcarina.Credentials, pth str
 }
 
 // Show echos the source command, for eval `carina env <name>`
-func (carina *CredentialsCommand) Show(pc *kingpin.ParseContext) error {
+func (carina *ShellCommand) Show(pc *kingpin.ParseContext) error {
 	if carina.Path == "" {
 		baseDir, err := CarinaCredentialsBaseDir()
 		if err != nil {
 			return err
 		}
-		carina.Path = path.Join(baseDir, clusterDirName, carina.Username, carina.ClusterName)
+		carina.Path = filepath.Join(baseDir, clusterDirName, carina.Username, carina.ClusterName)
 	}
 
-	envPath := path.Join(carina.Path, "docker.env")
+	envPath := getCredentialFilePath(carina.Path, carina.Shell)
 	_, err := os.Stat(envPath)
 	if os.IsNotExist(err) {
 		// Show is a NoAuth command, so we'll auth first for a download
@@ -697,7 +700,8 @@ func (carina *CredentialsCommand) Show(pc *kingpin.ParseContext) error {
 		}
 		return carina.Download(pc)
 	}
-	fmt.Fprintf(os.Stdout, "source '%v'\n", envPath)
+
+	fmt.Fprintln(os.Stdout, sourceHelpString(envPath, carina.ClusterName, carina.Shell))
 
 	err = carina.TabWriter.Flush()
 	return err

--- a/main.go
+++ b/main.go
@@ -659,8 +659,7 @@ func (carina *CredentialsCommand) Download(pc *kingpin.ParseContext) (err error)
 
 	fmt.Println("")
 	fmt.Printf("Credentials written to \"%s\"\n", p)
-	fmt.Printf("To see how to connect to your cluster, run: carina env %s\n", carina.ClusterName)
-	fmt.Println("")
+	fmt.Println(credentialsNextStepsString(carina.ClusterName))
 
 	err = carina.TabWriter.Flush()
 	return err


### PR DESCRIPTION
Cleanup our instruction text so that it makes sense on Windows as well. I based the `--shell` argument off of how Docker Machine works.

Fixes #57 

**Bash**

``` bash
$ carina credentials mccluster
#
# Credentials written to "/Users/caro8994/.carina/clusters/carolynvsrax/mccluster"
# To see how to connect to your cluster, run: carina env mccluster
#
$ carina env mccluster
source /Users/caro8994/.carina/clusters/carolynvsrax/mccluster/docker.env
# Run the command below to get your Docker environment variables set:
# eval $(carina env mccluster)

```

**Bash (Windows)**

``` bash
$ carina credentials mccluster
#
# Credentials written to "/Users/caro8994/.carina/clusters/carolynvsrax/mccluster"
# To see how to connect to your cluster, run: carina env mccluster --shell cmd|powershell|bash
#
$ carina env mccluster
source /Users/caro8994/.carina/clusters/carolynvsrax/mccluster/docker.env
# Run the command below to get your Docker environment variables set:
# eval $(carina env mccluster)

```

**PowerShell**

``` powershell
> carina credentials mccluster
#
# Credentials written to "C:\Users\caro8994\carina\clusters\carolynvsrax\mccluster"
# To see how to connect to your cluster, run: carina env mccluster --shell cmd|powershell|bash
#
> carina env mccluster --shell powershell
. C:\Users\caro8994\carina\clusters\carolynvsrax\mccluster\docker.ps1
# Run the command below to get your Docker environment variables set:
# carina env mccluster --shell powershell | iex
```

**CMD**

``` batchfile
> carina credentials mccluster
#
# Credentials written to "C:\Users\caro8994\carina\clusters\carolynvsrax\mccluster"
# To see how to connect to your cluster, run: carina env mccluster --shell cmd|powershell|bash
#
> carina env mccluster --shell cmd
# Run the command below to get your Docker environment variables set:
CALL C:\Users\caro8994\carina\clusters\carolynvsrax\mccluster\docker.cmd
```
