### PR TITLE
Include columns for grow and create

### DIFF
--- a/main.go
+++ b/main.go
@@ -479,6 +479,7 @@ func (carina *ClusterCommand) clusterApply(op clusterOp) (err error) {
 		return err
 	}
 
+	writeClusterHeader(carina.TabWriter)
 	err = writeCluster(carina.TabWriter, cluster)
 	if err != nil {
 		return err
@@ -590,6 +591,7 @@ func (carina *WaitClusterCommand) clusterApplyWait(op clusterOp) (err error) {
 		return err
 	}
 
+	writeClusterHeader(carina.TabWriter)
 	err = writeCluster(carina.TabWriter, cluster)
 	if err != nil {
 		return err


### PR DESCRIPTION
Create was also missing the headers. I've checked the other commands and they all seem fine.

``` bash
$ ./carina grow --by 1 test2
ClusterName         Flavor              Nodes               AutoScale           Status
test2               container1-4G       1                   false               growing

$ ./carina ls
ClusterName         Flavor              Nodes               AutoScale           Status
mccluster           container1-4G       2                   false               active
test                container1-4G       1                   false               active
test2               container1-4G       1                   false               growing

$ ./carina rm test
ClusterName         Flavor              Nodes               AutoScale           Status
test                container1-4G       1                   false               deleting

$ ./carina create test3
ClusterName         Flavor              Nodes               AutoScale           Status
test3               container1-4G       1                   false               new
```

Fixes #76 
