### PR TITLE
Document the user home directory env

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,6 +101,17 @@ func New() *Application {
 	app := kingpin.New("carina", "command line interface to launch and work with Docker Swarm clusters")
 	app.Version(VersionString())
 
+	baseDir, err := CarinaCredentialsBaseDir()
+	if err != nil {
+		panic(err)
+	}
+	envHelp := fmt.Sprintf(`Environment Variables:
+  CARINA_HOME
+    directory that stores your cluster tokens and credentials
+    current setting: %s
+`, baseDir)
+	app.UsageTemplate(kingpin.DefaultUsageTemplate + envHelp)
+
 	cap := new(Application)
 	ctx := new(Context)
 


### PR DESCRIPTION
Closes #66 by introducing some quick help at the bottom of the usage statement.

```
$ ./carina --help
usage: carina [<flags>] <command> [<args> ...]

command line interface to launch and work with Docker Swarm clusters

Flags:
  --help                   Show context-sensitive help (also try --help-long and --help-man).
  --version                Show application version.
  --username="kyle.kelley@rackspace.com"
                           Carina username - can also set env var CARINA_USERNAME
  --api-key=CARINA_APIKEY  Carina API Key - can also set env var CARINA_APIKEY
  --endpoint="https://app.getcarina.com"
                           Carina API endpoint
  --cache                  Cache API tokens and update times; defaults to true, use --no-cache to turn off

Commands:
  help [<command>...]
    Show help.

  create [<flags>] <cluster-name>
    Create a swarm cluster

  get [<flags>] <cluster-name>
    Get information about a swarm cluster

  ls
    List swarm clusters

  grow --by=BY <cluster-name>
    Grow a cluster by the requested number of nodes

  credentials [<flags>] <cluster-name>
    download credentials

  env [<flags>] <cluster-name>
    show source command for setting credential environment

  rebuild [<flags>] <cluster-name>
    Rebuild a swarm cluster

  rm [<flags>] <cluster-name>
    Remove a swarm cluster


Environment Variables:
  CARINA_HOME
    directory that stores your cluster tokens and credentials
    current setting: /Users/kyle6475/.carina
```
