### PR TITLE
Suggest using brew update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ To download and install the `carina` CLI, use the appropriate instructions for y
 
 #### OS X with Homebrew
 
-If you're using [Homebrew](http://brew.sh/), run the following command:
+If you're using [Homebrew](http://brew.sh/), run the following commands:
 
 ```bash
+$ brew update
 $ brew install carina
 ```
 


### PR DESCRIPTION
Ran into a problem where a user had old `brew`, resulting in an old version of `carina` being installed.

This has users run `brew update` first.
