### PR TITLE
Allow for segments instead of nodes.

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,6 +155,7 @@ func New() *Application {
 	createCommand := new(CreateCommand)
 	createCommand.WaitClusterCommand = cap.NewWaitClusterCommand(ctx, "create", "Create a swarm cluster")
 	createCommand.Flag("nodes", "number of nodes for the initial cluster").Default("1").IntVar(&createCommand.Nodes)
+	createCommand.Flag("segments", "number of nodes for the initial cluster").Default("1").Hidden().IntVar(&createCommand.Nodes)
 	createCommand.Flag("autoscale", "whether autoscale is on or off").BoolVar(&createCommand.AutoScale)
 	createCommand.Action(createCommand.Create)
 


### PR DESCRIPTION
Since we (and others) have tutorials using the `--segments` flag, I figured we should remain backwards compatible. `--segments` on create is now a hidden flag and will override the value for `--nodes` if set.

```
$ ./carina create --segments 2 moo
ClusterName         Flavor              Nodes               AutoScale           Status
moo                 container1-4G       2                   false               new
$ ./carina create --nodes 3 woot
ClusterName         Flavor              Nodes               AutoScale           Status
woot                container1-4G       3                   false               new
```
