### PR TITLE
Accept the shell argument for fish

### DIFF
--- a/credentials_nix.go
+++ b/credentials_nix.go
@@ -14,7 +14,12 @@ func credentialsNextStepsString(clusterName string) string {
 }
 
 func getCredentialFilePath(basepath string, shell string) string {
-	return filepath.Join(basepath, "docker.env")
+	switch shell {
+	case "fish":
+		return filepath.Join(basepath, "docker.fish")
+	default:
+		return filepath.Join(basepath, "docker.env")
+	}
 }
 
 func sourceHelpString(credentialFile string, clusterName string, shell string) string {


### PR DESCRIPTION
Rely on --shell in the same way Windows users deal with.

I made this use $SHELL at first then realized an inconsistency with the other
tooling. Would it be ok to make `--shell` the primary choice with a fallback
to whatever $SHELL is defined as to determine the script?

```
kyle@lack ~/c/s/g/g/carina> make; and ./carina env test2 --shell fish
go get ./...
CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -X github.com/getcarina/carina/version.Commit=f0818b51ab726075b500a11fd079a9c20eb5a1de -X github.com/getcarina/carina/version.Version=v1.3.0-8-gf0818b5' -o carina .
source /Users/rgbkrk/.carina/clusters/rgbkrk/test2/docker.fish
# Run the command below to get your Docker environment variables set:
# eval $(carina env test2)
```
