### PR TITLE
Handle an errored cluster when waiting for it to delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ local: $(GOFILES)
 	CGO_ENABLED=0 $(GOBUILD) -o carina .
 
 test: local
-	go test -v $(GOFILES_NOVENDOR)
+	go test $(GOFILES_NOVENDOR)
 	eval "$( ./carina bash-completion )"
 	./carina --version
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -27,7 +27,11 @@ func newDeleteCommand() *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("Deleting cluster (%s)\n", options.name)
+			if options.wait {
+				fmt.Printf("Deleted cluster (%s)\n", options.name)
+			} else {
+				fmt.Printf("Deleting cluster (%s)\n", options.name)
+			}
 
 			return nil
 		},

--- a/cmd/resize.go
+++ b/cmd/resize.go
@@ -1,47 +1,47 @@
 package cmd
 
 import (
-    "errors"
+	"errors"
 
-    "github.com/getcarina/carina/console"
-    "github.com/spf13/cobra"
+	"github.com/getcarina/carina/console"
+	"github.com/spf13/cobra"
 )
 
 func newResizeCommand() *cobra.Command {
-    var options struct {
-        name     string
-        nodes    int
-        wait     bool
-    }
+	var options struct {
+		name  string
+		nodes int
+		wait  bool
+	}
 
-    var cmd = &cobra.Command{
-        Use:               "resize <cluster-name>",
-        Short:             "Resize a cluster",
-        Long:              "Resize a cluster by setting the number of cluster nodes",
-        PersistentPreRunE: authenticatedPreRunE,
-        PreRunE: func(cmd *cobra.Command, args []string) error {
-            if options.nodes < 1 {
-                return errors.New("--nodes must be >= 1")
-            }
+	var cmd = &cobra.Command{
+		Use:               "resize <cluster-name>",
+		Short:             "Resize a cluster",
+		Long:              "Resize a cluster by setting the number of cluster nodes",
+		PersistentPreRunE: authenticatedPreRunE,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if options.nodes < 1 {
+				return errors.New("--nodes must be >= 1")
+			}
 
-            return bindClusterNameArg(args, &options.name)
-        },
-        RunE: func(cmd *cobra.Command, args []string) error {
-            cluster, err := cxt.Client.ResizeCluster(cxt.Account, options.name, options.nodes, options.wait)
-            if err != nil {
-                return err
-            }
+			return bindClusterNameArg(args, &options.name)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cluster, err := cxt.Client.ResizeCluster(cxt.Account, options.name, options.nodes, options.wait)
+			if err != nil {
+				return err
+			}
 
-            console.WriteCluster(cluster)
+			console.WriteCluster(cluster)
 
-            return nil
-        },
-    }
+			return nil
+		},
+	}
 
-    cmd.ValidArgs = []string{"cluster-name"}
-    cmd.Flags().IntVar(&options.nodes, "nodes", 1, "The desired number of nodes in the cluster")
-    cmd.Flags().BoolVar(&options.wait, "wait", false, "Wait for cluster to finish resizing and return to active")
-    cmd.SetUsageTemplate(cmd.UsageTemplate())
+	cmd.ValidArgs = []string{"cluster-name"}
+	cmd.Flags().IntVar(&options.nodes, "nodes", 1, "The desired number of nodes in the cluster")
+	cmd.Flags().BoolVar(&options.wait, "wait", false, "Wait for cluster to finish resizing and return to active")
+	cmd.SetUsageTemplate(cmd.UsageTemplate())
 
-    return cmd
+	return cmd
 }

--- a/common/log.go
+++ b/common/log.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"testing"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/davecgh/go-spew/spew"
@@ -93,4 +94,31 @@ func (log *consoleLogger) WriteError(format string, err error, a ...interface{})
 		dump := log.SDump(err)
 		log.Error(dump)
 	}
+}
+
+/*
+   Test Helpers
+*/
+type testingLogHook struct {
+	t *testing.T
+}
+
+func (hook *testingLogHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (hook *testingLogHook) Fire(event *logrus.Entry) error {
+	hook.t.Log(event.Message)
+	return nil
+}
+
+func (log *consoleLogger) RegisterTestLogger(t *testing.T) {
+	// Log to the test logger
+	Log.Hooks.Add(&testingLogHook{t: t})
+
+	// Log all levels
+	Log.SetDebug()
+
+	// Don't print to the console so that we abide by the go  test -v flag
+	Log.Out = ioutil.Discard
 }

--- a/glide.lock
+++ b/glide.lock
@@ -8,7 +8,7 @@ imports:
 - name: github.com/fsnotify/fsnotify
   version: fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197
 - name: github.com/getcarina/libcarina
-  version: 7730a4130dc0359123574a7d7cdb08ffee02a20d
+  version: c41d044bf97dc12d155de0d828829b500ed49cd6
   repo: https://github.com/getcarina/libcarina.git
   vcs: git
 - name: github.com/getcarina/libmakeswarm

--- a/magnum/magnum.go
+++ b/magnum/magnum.go
@@ -191,10 +191,10 @@ func (magnum *Magnum) DeleteCluster(token string) (common.Cluster, error) {
 
 	cluster, err := magnum.waitForTaskInitiated(token, "DELETE")
 	if err != nil {
-		err = errors.Cause(err)
+		cause := errors.Cause(err)
 
 		// Gracefully handle a 404 Not Found when the cluster is deleted quickly
-		if httpErr, ok := err.(*coe.ErrorResponse); ok {
+		if httpErr, ok := cause.(*coe.ErrorResponse); ok {
 			if httpErr.Actual == http.StatusNotFound {
 				cluster = newCluster()
 				cluster.Status = "DELETE_COMPLETE"
@@ -266,10 +266,10 @@ func (magnum *Magnum) WaitUntilClusterIsDeleted(cluster common.Cluster) error {
 		cluster, err := magnum.GetCluster(cluster.GetID())
 
 		if err != nil {
-			err = errors.Cause(err)
+			cause := errors.Cause(err)
 
 			// Gracefully handle a 404 Not Found when the cluster is deleted quickly
-			if httpErr, ok := err.(*coe.ErrorResponse); ok {
+			if httpErr, ok := cause.(*coe.ErrorResponse); ok {
 				if httpErr.Actual == http.StatusNotFound {
 					return nil
 				}

--- a/make-coe/account.go
+++ b/make-coe/account.go
@@ -21,6 +21,9 @@ type Account struct {
 	APIKey           string
 	Region           string
 
+	// Testing only, not used by the cli
+	AuthEndpointOverride string
+
 	// The endpoint from the service catalog
 	endpoint string
 	token    string
@@ -72,7 +75,7 @@ func (account *Account) Authenticate() (*libcarina.CarinaClient, error) {
 	} else {
 		common.Log.WriteDebug("[make-coe] Attempting to authenticate with a username and apikey")
 	}
-	carinaClient, err := libcarina.NewClient(account.UserName, account.APIKey, account.Region, account.token, account.endpoint)
+	carinaClient, err := libcarina.NewClient(account.UserName, account.APIKey, account.Region, account.AuthEndpointOverride, account.token, account.endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "[make-coe] Authentication failed")
 	}

--- a/make-coe/account.go
+++ b/make-coe/account.go
@@ -92,7 +92,7 @@ func (account *Account) Authenticate() (*libcarina.CarinaClient, error) {
 	common.Log.WriteDebug("[make-coe] Checking server API version")
 	metadata, err := carinaClient.GetAPIMetadata()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Unable to parse API version response")
 	}
 	if !metadata.IsSupportedVersion() {
 		min, max := metadata.GetSupportedVersionRange()

--- a/make-coe/make-coe.go
+++ b/make-coe/make-coe.go
@@ -222,7 +222,6 @@ func (carina *MakeCOE) WaitUntilClusterIsActive(cluster common.Cluster) (common.
 	for {
 		cluster, err := carina.GetCluster(cluster.GetID())
 		if err != nil {
-			err = errors.Cause(err)
 			return nil, err
 		}
 
@@ -253,10 +252,10 @@ func (carina *MakeCOE) WaitUntilClusterIsDeleted(cluster common.Cluster) error {
 	for {
 		cluster, err := carina.GetCluster(cluster.GetID())
 		if err != nil {
-			err = errors.Cause(err)
+			cause := errors.Cause(err)
 
 			// Gracefully handle a 404 Not Found when the cluster is deleted quickly
-			if httpErr, ok := err.(libcarina.HTTPErr); ok {
+			if httpErr, ok := cause.(libcarina.HTTPErr); ok {
 				if httpErr.StatusCode == http.StatusNotFound {
 					return nil
 				}

--- a/make-coe/make-coe_test.go
+++ b/make-coe/make-coe_test.go
@@ -2,7 +2,6 @@ package makecoe
 
 import (
 	"net/http"
-	"os"
 	"testing"
 
 	"fmt"
@@ -22,6 +21,8 @@ func TestDeleteClusterThenErrorOutHaltsWait(t *testing.T) {
 			fmt.Fprintln(w, `{"versions": [{"status": "current", "min_version": "1.0", "max_version": "1.0", "id": "v1.0"}]}`)
 		case "/clusters/99999999-9999-9999-9999-999999999999":
 			fmt.Fprintln(w, `{ "status": "error" }`)
+		case "/v2.0/tokens":
+			fmt.Fprintln(w, `{"access":{"serviceCatalog":[{"endpoints":[{"tenantId":"963451","publicURL":"https:\/\/api.dfw.getcarina.com","region":"DFW"}],"name":"cloudContainer","type":"rax:container"}],"user":{"name":"fake-user","id":"fake-userid"},"token":{"expires":"3000-01-01T12:00:00Z","id":"fake-token","tenant":{"name":"fake-tenantname","id":"fake-tenantid"}}}}`)
 		default:
 			fmt.Fprintln(w, "unexpected request: "+r.RequestURI)
 			w.WriteHeader(404)
@@ -30,9 +31,10 @@ func TestDeleteClusterThenErrorOutHaltsWait(t *testing.T) {
 	defer mockCarina.Close()
 
 	acct := &Account{
+		AuthEndpointOverride: mockCarina.URL + "/v2.0/",
 		EndpointOverride:     mockCarina.URL,
-		UserName:         os.Getenv("RS_USERNAME"),
-		APIKey:           os.Getenv("RS_API_KEY"),
+		UserName:             "fake-user",
+		APIKey:               "fake-apikey",
 		Region:               "DFW",
 	}
 

--- a/make-coe/make-coe_test.go
+++ b/make-coe/make-coe_test.go
@@ -1,0 +1,55 @@
+package makecoe
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"fmt"
+	"net/http/httptest"
+
+	"github.com/getcarina/carina/common"
+)
+
+func TestDeleteClusterThenErrorOutHaltsWait(t *testing.T) {
+	common.Log.RegisterTestLogger(t)
+
+	mockCarina := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.RequestURI {
+		case "/":
+			fmt.Fprintln(w, `{"versions": [{"status": "current", "min_version": "1.0", "max_version": "1.0", "id": "v1.0"}]}`)
+		case "/clusters/99999999-9999-9999-9999-999999999999":
+			fmt.Fprintln(w, `{ "status": "error" }`)
+		default:
+			fmt.Fprintln(w, "unexpected request: "+r.RequestURI)
+			w.WriteHeader(404)
+		}
+	}))
+	defer mockCarina.Close()
+
+	acct := &Account{
+		EndpointOverride:     mockCarina.URL,
+		UserName:         os.Getenv("RS_USERNAME"),
+		APIKey:           os.Getenv("RS_API_KEY"),
+		Region:               "DFW",
+	}
+
+	svc := &MakeCOE{Account: acct}
+	cluster := newCluster()
+	cluster.Name = "test"
+	cluster.ID = "99999999-9999-9999-9999-999999999999"
+
+	err := svc.WaitUntilClusterIsDeleted(cluster)
+	if err == nil {
+		t.Error("WaitUntilClusterIsDeleted didn't stop when the cluster was in the error state.")
+	} else {
+		actualError := err.Error()
+		expectedError := "Unable to delete cluster, an error occured while deleting."
+		if expectedError != actualError {
+			t.Errorf("Expected error: %s\nActual Error: %+v", expectedError, err)
+
+		}
+	}
+}


### PR DESCRIPTION
/cc @thomasem If you review one PR this year, this is the one! 😉 

* carina delete --wait will now stop when the cluster errors
* Our first unit test! Now with more mocking!
* Cleanup our errors so that we have stacktraces coming out of libcarina