### PR TITLE
Build against go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.6
+- 1.7
 git:
   depth: 9999999
 install:


### PR DESCRIPTION
Mac OS Sierra has backwards-incompatible changes that require using a newer version of go with Sierra support. See https://github.com/golang/go/issues/17492#issuecomment-254433110