### PR TITLE
Allow specifying the current profile with CARINA_PROFILE

### DIFF
--- a/cmd/carina.go
+++ b/cmd/carina.go
@@ -48,7 +48,7 @@ func newCarinaCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&cxt.Silent, "silent", false, "Do not print to stdout")
 
 	// Account flags
-	cmd.PersistentFlags().StringVar(&cxt.Profile, "profile", "", "Use saved credentials from a profile")
+	cmd.PersistentFlags().StringVar(&cxt.Profile, "profile", "", "Use saved credentials from a profile [CARINA_PROFILE]")
 	cmd.PersistentFlags().BoolVar(&cxt.ProfileDisabled, "no-profile", false, "Ignore profiles and use flags and/or environment variables only")
 	cmd.PersistentFlags().StringVar(&cxt.Username, "username", "", "Username [CARINA_USERNAME/RS_USERNAME/OS_USERNAME]")
 	cmd.PersistentFlags().StringVar(&cxt.APIKey, "apikey", "", "Public Cloud API Key [CARINA_APIKEY/RS_API_KEY]")

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -14,6 +14,9 @@ import (
 	"github.com/spf13/viper"
 )
 
+// CarinaProfileEnvVar is the name of the Carina profile to use
+const CarinaProfileEnvVar = "CARINA_PROFILE"
+
 // CarinaUserNameEnvVar is the Carina username environment variable (1st)
 const CarinaUserNameEnvVar = "CARINA_USERNAME"
 
@@ -195,10 +198,18 @@ func (cxt *context) loadProfile() (ok bool, err error) {
 	common.Log.WriteDebug("Loading profiles")
 	configFile := viper.ConfigFileUsed()
 
-	// Try to use the default profile
-	if cxt.Profile == "" && viper.InConfig("default") {
-		cxt.Profile = "default"
-		return cxt.loadProfile()
+	if cxt.Profile == "" {
+		cxt.Profile = os.Getenv(CarinaProfileEnvVar)
+		if cxt.Profile != "" {
+			common.Log.WriteDebug("Profile: %s", CarinaProfileEnvVar)
+		}
+	}
+	if cxt.Profile == "" {
+		// Try to use the default profile
+		if viper.InConfig("default") {
+			cxt.Profile = "default"
+			common.Log.WriteDebug("Profile: default")
+		}
 	}
 
 	profile := viper.GetStringMapString(cxt.Profile)

--- a/make-coe/make-coe_test.go
+++ b/make-coe/make-coe_test.go
@@ -2,9 +2,9 @@ package makecoe
 
 import (
 	"net/http"
-	"testing"
 	"regexp"
 	"strings"
+	"testing"
 
 	"fmt"
 	"net/http/httptest"
@@ -33,15 +33,15 @@ func identityHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func clusterInErrorHandler(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json")
 
-		switch {
-		case anyClusterRegexp.MatchString(r.RequestURI):
-			fmt.Fprintln(w, `{ "status": "error" }`)
-		default:
-			fmt.Fprintln(w, "unexpected request: "+r.RequestURI)
-			w.WriteHeader(404)
-		}
+	switch {
+	case anyClusterRegexp.MatchString(r.RequestURI):
+		fmt.Fprintln(w, `{ "status": "error" }`)
+	default:
+		fmt.Fprintln(w, "unexpected request: "+r.RequestURI)
+		w.WriteHeader(404)
+	}
 }
 
 func microversionUnsupportedHandler(w http.ResponseWriter, r *http.Request) {
@@ -72,11 +72,11 @@ func assertMicroversionUnsupportedMessaging(t *testing.T, err error) {
 
 	actualError := err.Error()
 
-	if ! strings.Contains(actualError, microversionUnsupportedUpdateClientSubstring) {
+	if !strings.Contains(actualError, microversionUnsupportedUpdateClientSubstring) {
 		t.Errorf("\nExpected error with:\n\"%s\",\nInstead got:\n\"%s\"\n", microversionUnsupportedUpdateClientSubstring, err)
 	}
 
-	if ! strings.Contains(actualError, microversionUnsupportedErrorMessageSubstring) {
+	if !strings.Contains(actualError, microversionUnsupportedErrorMessageSubstring) {
 		t.Errorf("\nExpected error with:\n\"%s\",\nInstead got:\n\"%s\"\n", microversionUnsupportedErrorMessageSubstring, err)
 	}
 }


### PR DESCRIPTION
The precedence is --profile, then CARINA_PROFILE, then the default profile.