### PR TITLE
Change how we install glide to work with homebew's build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ go:
 - 1.7
 git:
   depth: 9999999
-sudo: required
 install:
-- sudo -E PATH=$PATH make get-deps
+- make get-deps
 script:
 - make test
 - make cross-build

--- a/script/install-glide.sh
+++ b/script/install-glide.sh
@@ -13,15 +13,17 @@ if type glide &> /dev/null ; then
 fi
 
 echo "Installing glide v0.11.1..."
-git clone https://github.com/Masterminds/glide.git $GOPATH/src/github.com/Masterminds/glide
+if [ ! -d "$GOPATH/src/github.com/Masterminds/glide" ]; then
+  git clone https://github.com/Masterminds/glide.git $GOPATH/src/github.com/Masterminds/glide
+fi
 cd $GOPATH/src/github.com/Masterminds/glide
 git checkout v0.11.1
-make install
+go install --ldflags="-X main.version=v0.11.1" github.com/Masterminds/glide
 
 if type glide &> /dev/null ; then
     echo "Done!"
     exit 0
 else
-    echo "Could not find glide after installing it. Aborting..."
+    echo "Could not find glide after installing it. Make sure GOPATH/bin is in PATH. Aborting..."
     exit 1
 fi


### PR DESCRIPTION
`make install` put the glide binary in `/user/local/bin` and tried to change permissions, which was causing permission errors. Relying on the Go bin/ seems to work around that adequately.