### PR TITLE
Ignore missing default profile

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -209,6 +209,9 @@ func (cxt *context) loadProfile() (ok bool, err error) {
 		if viper.InConfig("default") {
 			cxt.Profile = "default"
 			common.Log.WriteDebug("Profile: default")
+		} else {
+			common.Log.WriteDebug("Profile: none")
+			return false, nil
 		}
 	}
 

--- a/cmd/quotas.go
+++ b/cmd/quotas.go
@@ -23,8 +23,8 @@ func newQuotasCommand() *cobra.Command {
 			maxNodesPerCluster := strconv.Itoa(quotas.GetMaxNodesPerCluster())
 
 			data := []console.Tuple{
-				{"Max Clusters", maxClusters},
-				{"Max Nodes per Cluster", maxNodesPerCluster},
+				{Key: "Max Clusters", Value: maxClusters},
+				{Key: "Max Nodes per Cluster", Value: maxNodesPerCluster},
 			}
 			console.WriteMap(data)
 


### PR DESCRIPTION
We shouldn't assume that because there is a configuration file, that a default profile is present. If one is not there, and no profile was specified, move on to looking at environment variables.