### PR TITLE
Explicitly set the repo for yaml.v2

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,4 +1,4 @@
-hash: c257c7fd57c183f96ddb0b95e65f9b736246bdfda08465fa1f5f8cccee7bac56
+hash: 21808762abe2c2931a10471c6824047d3b3944fa2964ef87fd94b67a0c4bea11
 updated: 2017-02-06T10:34:03.651359382-06:00
 imports:
 - name: github.com/davecgh/go-spew
@@ -115,4 +115,6 @@ imports:
   - unicode/norm
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+  repo: https://github.com/go-yaml/yaml.git
+  vcs: git
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,3 +34,6 @@ import:
   vcs: git
 - package: github.com/stretchr/testify
   version: ^1.1.4
+- package: gopkg.in/yaml.v2
+  version: v2
+  repo: https://github.com/go-yaml/yaml.git


### PR DESCRIPTION
When building for homebrew with `brew install --build-bottle --verbose carina` glide (same version as before) is suddenly unable to retrieve the repo for `gopkg.in/yaml.v2`. This doesn't reproduce when I run `make get-deps` locally or on Travis, but consistently reproduces during a hombrew build now.

I found a workaround from https://github.com/Masterminds/glide/issues/449#issuecomment-262105353 that seems to work. Not sure why it's broke but this seems to fix it.